### PR TITLE
SNS - ADC : pin-type fix

### DIFF
--- a/lib/io/adc.cpp
+++ b/lib/io/adc.cpp
@@ -5,7 +5,7 @@
 
 namespace hyped::io {
 
-Adc::Adc(const uint32_t pin) : pin_(pin)
+Adc::Adc(const uint8_t pin) : pin_(pin)
 {
   char buf[100];
   snprintf(buf, sizeof(buf), "/sys/bus/iio/devices/iio:device0/in_voltage%i_raw", pin_);

--- a/lib/io/adc.hpp
+++ b/lib/io/adc.hpp
@@ -12,7 +12,7 @@ class Adc {
   /**
    * @param pin is one of the 6 analogue input pins on the bbb
    */
-  Adc(const uint32_t pin);
+  Adc(const uint8_t pin);
   ~Adc();
 
   /**


### PR DESCRIPTION
quick pr to fix pin being a uint32 and not a uint8