### PR TITLE
SNS - ADC Error Handling

### DIFF
--- a/lib/io/adc.cpp
+++ b/lib/io/adc.cpp
@@ -1,7 +1,7 @@
 #include "adc.hpp"
 
-#include <fcntl.h>   // define O_WONLY and O_RDONLY
-#include <unistd.h>  // close()
+#include <fcntl.h>
+#include <unistd.h>
 
 namespace hyped::io {
 

--- a/lib/io/adc.cpp
+++ b/lib/io/adc.cpp
@@ -20,6 +20,10 @@ Adc::~Adc()
 
 std::optional<std::uint16_t> Adc::readValue()
 {
+  if (file_ < 0) {
+    logger_.log(core::LogLevel::kFatal, "Unable to find ADC file during read");
+    return std::nullopt;
+  }
   const std::optional<std::uint16_t> raw_voltage = resetAndRead4(file_);
   if (raw_voltage) {
     logger_.log(
@@ -37,13 +41,10 @@ std::optional<std::uint16_t> Adc::resetAndRead4(const int file_descriptor)
     return std::nullopt;
   }
   char read_buffer[4];  // buffer size 4 for fs value
-  const int num_bytes_read
-    = read(file_descriptor,
-           &read_buffer,
-           sizeof(read_buffer));  // actually consume new data, changes value in buffer
-  if (num_bytes_read < 2) {       // 2 bytes minimum as value ranges from [0, 4095]
+  const int num_bytes_read = read(file_descriptor, &read_buffer, sizeof(read_buffer));
+  if (num_bytes_read < 2) {  // 2 bytes minimum as value ranges from [0, 4095]
     logger_.log(core::LogLevel::kFatal, "Failed to read sufficient bytes from ADC");
-    return std::nullopt;  // returning NULL since we did not get any value
+    return std::nullopt;
   }
   const int raw_voltage = std::atoi(read_buffer);
   return static_cast<std::uint16_t>(raw_voltage);  // max value is 2^12-1 = 4095

--- a/lib/io/adc.hpp
+++ b/lib/io/adc.hpp
@@ -19,19 +19,17 @@ class Adc {
 
   /**
    * @brief reads AIN value from file system
-   *
    * @return std::uint16_t return two bytes for [0,4095] range
    *         because the BBB has 12-bit ADCs (2^12 = 4096)
    */
   std::optional<std::uint16_t> readValue();
 
+ private:
   /**
    * @param    file_descriptor specifying the file voltage values are read from
    * @return   std::uint16_t returns two bytes of current voltage data
    */
   std::optional<std::uint16_t> resetAndRead4(const int file_descriptor);
-
- private:
   core::ILogger &logger_;
   std::uint8_t pin_;
   int file_;


### PR DESCRIPTION
Realised we never checked for fd error during the actual read and only logged during the construction. Also made helper function private. 