### PR TITLE
SNS - Dummy Spi

### DIFF
--- a/lib/io/hardware_i2c.cpp
+++ b/lib/io/hardware_i2c.cpp
@@ -17,7 +17,7 @@ std::optional<HardwareI2c> HardwareI2c::create(core::ILogger &logger,
                                                const std::uint8_t bus_address)
 {
   char path[13];  // up to "/dev/i2c-2"
-  sprintf(path, "/dev/i2c-%d", bus_address);
+  snprintf(path, sizeof(path), "/dev/i2c-%d", bus_address);
   const int file_descriptor = open(path, O_RDWR, 0);
   if (file_descriptor < 0) {
     logger.log(core::LogLevel::kFatal, "Failed to find i2c device");

--- a/lib/utils/dummy_spi.cpp
+++ b/lib/utils/dummy_spi.cpp
@@ -1,0 +1,19 @@
+#include "dummy_spi.hpp"
+
+namespace hyped::utils {
+
+core::Result DummySpi::read(const std::uint8_t addr,
+                            const std::uint8_t *rx,
+                            const std::uint16_t len)
+{
+  return core::Result::kFailure;
+}
+
+core::Result DummySpi::write(const std::uint8_t addr,
+                             const std::uint8_t *tx,
+                             const std::uint16_t len)
+{
+  return core::Result::kFailure;
+}
+
+}  // namespace hyped::utils

--- a/lib/utils/dummy_spi.hpp
+++ b/lib/utils/dummy_spi.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <io/spi.hpp>
+
+namespace hyped::utils {
+
+/**
+ * Provides a basic implementation of the ISpi interface.
+ * This implementation does not actually communicate with any hardware.
+ * It is intended to be used in unit tests.
+ */
+class DummySpi : public io::ISpi {
+ public:
+  DummySpi()  = default;
+  ~DummySpi() = default;
+
+  core::Result read(const std::uint8_t addr, const std::uint8_t *rx, const std::uint16_t len);
+  core::Result write(const std::uint8_t addr, const std::uint8_t *tx, const std::uint16_t len);
+};
+
+}  // namespace hyped::utils

--- a/test/utils/dummy_spi.cpp
+++ b/test/utils/dummy_spi.cpp
@@ -1,0 +1,14 @@
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+#include <utils/dummy_spi.hpp>
+
+namespace hyped::test {
+
+TEST(DummySpi, construction)
+{
+  utils::DummySpi dummy_spi;
+}
+
+}  // namespace hyped::test


### PR DESCRIPTION
Adds a super basic and trivial dummy spi class with a very simple construction test. 
This is in advance of the completion of the dummy testing suite for I/O for the HYPED hackathon to take place sometime soon™.