### PR TITLE
SNS - Dummy Adc

### DIFF
--- a/lib/debug/repl.hpp
+++ b/lib/debug/repl.hpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 #include <core/logger.hpp>
-#include <io/adc.hpp>
+#include <io/hardware_adc.hpp>
 #include <io/hardware_gpio.hpp>
 #include <io/hardware_i2c.hpp>
 #include <io/hardware_spi.hpp>

--- a/lib/io/adc.hpp
+++ b/lib/io/adc.hpp
@@ -1,42 +1,17 @@
 #pragma once
 
 #include <cstdint>
-#include <cstdio>
-#include <cstdlib>  // for atoi
 #include <optional>
-
-#include <core/logger.hpp>
 
 namespace hyped::io {
 
-class Adc {
+class IAdc {
  public:
   /**
-   * @brief Creates an Adc instance
-   * @param pin is one of the 6 analogue input pins on the bbb
-   */
-  static std::optional<Adc> create(core::ILogger &logger, const std::uint8_t pin);
-  ~Adc();
-
-  /**
-   * @brief reads AIN value from file system
-   * @return std::uint16_t return two bytes for [0,4095] range
-   *         because the BBB has 12-bit ADCs (2^12 = 4096)
+   * @brief reads AIN value
+   * @return two bytes in range [0,4095] because the BBB has 12-bit ADCs (2^12 = 4096)
    */
   std::optional<std::uint16_t> readValue();
-
- private:
-  Adc(core::ILogger &logger, const int file_descriptor);
-  /**
-   * @param    file_descriptor specifying the file voltage values are read from
-   * @return   std::uint16_t returns two bytes of current voltage data
-   */
-  std::optional<std::uint16_t> resetAndRead4(const int file_descriptor);
-
- private:
-  core::ILogger &logger_;
-  std::uint8_t pin_;
-  const int file_descriptor_;
 };
 
 }  // namespace hyped::io

--- a/lib/io/hardware_adc.cpp
+++ b/lib/io/hardware_adc.cpp
@@ -1,4 +1,4 @@
-#include "adc.hpp"
+#include "hardware_adc.hpp"
 
 #include <fcntl.h>
 #include <unistd.h>

--- a/lib/io/hardware_adc.hpp
+++ b/lib/io/hardware_adc.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "adc.hpp"
+
+#include <cstdio>
+#include <cstdlib>  // for atoi
+
+#include <core/logger.hpp>
+
+namespace hyped::io {
+
+class Adc : public IAdc {
+ public:
+  /**
+   * @brief Creates an Adc instance
+   * @param pin is one of the 6 analogue input pins on the bbb
+   */
+  static std::optional<Adc> create(core::ILogger &logger, const std::uint8_t pin);
+  ~Adc();
+
+  std::optional<std::uint16_t> readValue();
+
+ private:
+  Adc(core::ILogger &logger, const int file_descriptor);
+  /**
+   * @param    file_descriptor specifying the file voltage values are read from
+   * @return   std::uint16_t returns two bytes of current voltage data
+   */
+  std::optional<std::uint16_t> resetAndRead4(const int file_descriptor);
+
+ private:
+  core::ILogger &logger_;
+  std::uint8_t pin_;
+  const int file_descriptor_;
+};
+
+}  // namespace hyped::io

--- a/lib/io/hardware_i2c.cpp
+++ b/lib/io/hardware_i2c.cpp
@@ -17,7 +17,7 @@ std::optional<HardwareI2c> HardwareI2c::create(core::ILogger &logger,
                                                const std::uint8_t bus_address)
 {
   char path[13];  // up to "/dev/i2c-2"
-  sprintf(path, "/dev/i2c-%d", bus_address);
+  snprintf(path, sizeof(path), "/dev/i2c-%d", bus_address);
   const int file_descriptor = open(path, O_RDWR, 0);
   if (file_descriptor < 0) {
     logger.log(core::LogLevel::kFatal, "Failed to find i2c device");

--- a/lib/utils/dummy_adc.cpp
+++ b/lib/utils/dummy_adc.cpp
@@ -1,0 +1,10 @@
+#include "dummy_adc.hpp"
+
+namespace hyped::utils {
+
+std::optional<std::uint16_t> DummyAdc::readValue()
+{
+  return std::nullopt;
+}
+
+}  // namespace hyped::utils

--- a/lib/utils/dummy_adc.hpp
+++ b/lib/utils/dummy_adc.hpp
@@ -1,0 +1,13 @@
+#include <io/adc.hpp>
+
+namespace hyped::utils {
+
+class DummyAdc : public io::IAdc {
+ public:
+  DummyAdc()  = default;
+  ~DummyAdc() = default;
+
+  std::optional<std::uint16_t> readValue();
+};
+
+}  // namespace hyped::utils

--- a/lib/utils/dummy_adc.hpp
+++ b/lib/utils/dummy_adc.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <io/adc.hpp>
 
 namespace hyped::utils {

--- a/test/utils/dummy_adc.cpp
+++ b/test/utils/dummy_adc.cpp
@@ -1,0 +1,14 @@
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+#include <utils/dummy_adc.hpp>
+
+namespace hyped::test {
+
+TEST(DummyAdc, construction)
+{
+  utils::DummyAdc dummy_adc;
+}
+
+}  // namespace hyped::test


### PR DESCRIPTION
Adding missing dummy adc with trivial construction test.
Again, adding this in preparation for the completion of the software-only I/O tests during the HYPED™ hackathon.