### PR TITLE
SNS - IO Fix

### DIFF
--- a/config/template.json
+++ b/config/template.json
@@ -11,7 +11,8 @@
 			},
 			"pwm": {
 				"enabled": false,
-				"modules": []
+				"modules": [],
+				"period": []
 			},
 			"spi": {
 				"enabled": false,

--- a/lib/debug/repl.cpp
+++ b/lib/debug/repl.cpp
@@ -116,6 +116,12 @@ std::optional<std::unique_ptr<Repl>> Repl::fromFile(const std::string &path)
       return std::nullopt;
     }
     const auto modules = pwm["modules"].GetArray();
+    if (!pwm.HasMember("period")) {
+      logger_.log(core::LogLevel::kFatal,
+                  "Missing required field 'io.pwm.period' in configuration file");
+      return std::nullopt;
+    }
+    const std::uint32_t period = pwm["period"].GetUint();
     for (auto &module : modules) {
       const std::uint8_t module_id = module.GetUint();
       if (module_id > 7 || module_id < 0) {
@@ -123,7 +129,7 @@ std::optional<std::unique_ptr<Repl>> Repl::fromFile(const std::string &path)
           core::LogLevel::kFatal, "Invalid module id %d in configuration file", module_id);
         return std::nullopt;
       }
-      repl->addPwmCommands(module_id);
+      repl->addPwmCommands(module_id, period);
     }
   }
   if (!io.HasMember("spi")) {
@@ -356,10 +362,11 @@ void Repl::addI2cCommands(const std::uint8_t bus)
   }
 }
 
-void Repl::addPwmCommands(const std::uint8_t module)
+void Repl::addPwmCommands(const std::uint8_t module, const std::uint32_t period)
 {
   const io::PwmModule pwm_module = static_cast<io::PwmModule>(module);
-  const auto optional_pwm        = io::Pwm::create(logger_, pwm_module);
+  const auto optional_pwm
+    = io::Pwm::create(logger_, pwm_module, period, hyped::io::Polarity::kActiveHigh);
   if (!optional_pwm) {
     logger_.log(core::LogLevel::kFatal, "Failed to create PWM module");
     return;
@@ -384,20 +391,9 @@ void Repl::addPwmCommands(const std::uint8_t module)
       std::cout << "Polarity (0 for active high and 1 for active low): ";
       std::cin >> polarity;
       std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-      const core::Result period_set_result = pwm->setPeriod(period);
-      if (period_set_result == core::Result::kFailure) {
-        logger_.log(core::LogLevel::kFatal, "Failed to set PWM period");
-        return;
-      }
       const core::Result duty_cycle_set_result = pwm->setDutyCycleByPercentage(duty_cycle);
       if (duty_cycle_set_result == core::Result::kFailure) {
         logger_.log(core::LogLevel::kFatal, "Failed to set PWM duty cycle");
-        return;
-      }
-      const core::Result polarity_set_result
-        = pwm->setPolarity(static_cast<io::Polarity>(polarity));
-      if (polarity_set_result == core::Result::kFailure) {
-        logger_.log(core::LogLevel::kFatal, "Failed to set PWM polarity");
         return;
       }
       const core::Result enable_result = pwm->setMode(io::Mode::kRun);

--- a/lib/debug/repl.hpp
+++ b/lib/debug/repl.hpp
@@ -41,7 +41,7 @@ class Repl {
   void addHelpCommand();
   void addAdcCommands(const std::uint8_t pin);
   void addI2cCommands(const std::uint8_t bus);
-  void addPwmCommands(const std::uint8_t module);
+  void addPwmCommands(const std::uint8_t module, const std::uint32_t period);
   void addSpiCommands(const std::uint8_t bus);
   void addAccelerometerCommands(const std::uint8_t bus, const std::uint8_t device_address);
   void addTemperatureCommands(const std::uint8_t bus, const std::uint8_t device_address);

--- a/lib/io/hardware_gpio_alt.cpp
+++ b/lib/io/hardware_gpio_alt.cpp
@@ -86,8 +86,7 @@ std::optional<std::shared_ptr<IGpioReader>> HardwareGpio::getReader(const std::u
     logger_.log(core::LogLevel::kFatal, "Failed to get file descriptor for GPIO %d", pin);
     return std::nullopt;
   }
-  HardwareGpioReader reader(logger_, read_file_descriptor);
-  return std::make_shared<HardwareGpioReader>(reader);
+  return std::make_shared<HardwareGpioReader>(logger_, read_file_descriptor);
 }
 
 std::optional<std::shared_ptr<IGpioWriter>> HardwareGpio::getWriter(const std::uint8_t pin,
@@ -103,8 +102,7 @@ std::optional<std::shared_ptr<IGpioWriter>> HardwareGpio::getWriter(const std::u
     logger_.log(core::LogLevel::kFatal, "Failed to get file descriptor for GPIO %d", pin);
     return std::nullopt;
   }
-  HardwareGpioWriter writer(logger_, write_file_descriptor);
-  return std::make_shared<HardwareGpioWriter>(writer);
+  return std::make_shared<HardwareGpioWriter>(logger_, write_file_descriptor);
 }
 
 core::Result HardwareGpio::exportPin(const std::uint8_t pin)

--- a/lib/io/hardware_gpio_alt.hpp
+++ b/lib/io/hardware_gpio_alt.hpp
@@ -14,37 +14,35 @@ namespace hyped::io {
 enum class Edge { kNone = 0, kRising, kFalling, kBoth };
 enum class Direction { kIn = 0, kOut };
 
+class HardwareGpio;  // forward declaration
 class HardwareGpioReader : public IGpioReader {
  public:
+  HardwareGpioReader(core::ILogger &logger, const int read_file_descritor);
+  ~HardwareGpioReader();
   /**
    * @brief Read a high or low from the GPIO pin.
    */
   virtual std::optional<core::DigitalSignal> read();
-  ~HardwareGpioReader();
 
  private:
-  HardwareGpioReader(core::ILogger &logger, const int read_file_descritor);
-
   core::ILogger &logger_;
   const int read_file_descriptor_;
-  friend class HardwareGpio;
 };
 
 class HardwareGpioWriter : public IGpioWriter {
  public:
+  HardwareGpioWriter(core::ILogger &logger, const int write_file_descriptor);
+  ~HardwareGpioWriter();
+
   /**
    * @brief Writes a high or low to the GPIO pin.
    * @param state The digital signal to write to the pin.
    */
   virtual core::Result write(const core::DigitalSignal state);
-  ~HardwareGpioWriter();
 
  private:
-  HardwareGpioWriter(core::ILogger &logger, const int write_file_descriptor);
-
   core::ILogger &logger_;
   const int write_file_descriptor_;
-  friend class HardwareGpio;
 };
 
 /**

--- a/lib/io/pwm.cpp
+++ b/lib/io/pwm.cpp
@@ -5,7 +5,10 @@
 
 namespace hyped::io {
 
-std::optional<std::shared_ptr<Pwm>> Pwm::create(core::ILogger &logger, const PwmModule pwm_module)
+std::optional<std::shared_ptr<Pwm>> Pwm::create(core::ILogger &logger,
+                                                const PwmModule pwm_module,
+                                                const std::uint32_t period,
+                                                const Polarity polarity)
 {
   const std::string pwm_address    = "/sys/class/pwm/" + getPwmFolderName(pwm_module) + "/";
   const std::string period_address = pwm_address + "period";
@@ -14,63 +17,101 @@ std::optional<std::shared_ptr<Pwm>> Pwm::create(core::ILogger &logger, const Pwm
     logger.log(core::LogLevel::kFatal, "Failed to open PWM period file");
     return std::nullopt;
   }
-  const std::string duty_cycle_address = pwm_address + "duty_cycle";
-  const int duty_cycle_file            = open(duty_cycle_address.c_str(), O_WRONLY);
-  if (duty_cycle_file < 0) {
-    logger.log(core::LogLevel::kFatal, "Failed to open PWM duty cycle file");
+  const core::Result period_result = setPeriod(period, period_file);
+  if (period_result == core::Result::kFailure) {
+    logger.log(core::LogLevel::kFatal, "Failed to set PWM period");
     return std::nullopt;
   }
+  logger.log(core::LogLevel::kDebug, "Successfully set PWM period to %d", period);
   const std::string polarity_address = pwm_address + "polarity";
   const int polarity_file            = open(polarity_address.c_str(), O_WRONLY);
   if (polarity_file < 0) {
     logger.log(core::LogLevel::kFatal, "Failed to open PWM polarity file");
     return std::nullopt;
   }
+  const core::Result polarity_result = setPolarity(polarity, polarity_file);
+  if (polarity_result == core::Result::kFailure) {
+    logger.log(core::LogLevel::kFatal, "Failed to set PWM polarity");
+    return std::nullopt;
+  }
+  logger.log(core::LogLevel::kDebug, "Successfully set PWM polarity to %d", polarity);
   const std::string enable_address = pwm_address + "enable";
   const int enable_file            = open(enable_address.c_str(), O_WRONLY);
   if (enable_file < 0) {
     logger.log(core::LogLevel::kFatal, "Failed to open PWM enable file");
     return std::nullopt;
   }
+  const std::string duty_cycle_address = pwm_address + "duty_cycle";
+  const int duty_cycle_file            = open(duty_cycle_address.c_str(), O_WRONLY);
+  if (duty_cycle_file < 0) {
+    logger.log(core::LogLevel::kFatal, "Failed to open PWM duty cycle file");
+    return std::nullopt;
+  }
   logger.log(core::LogLevel::kDebug, "Successfully initialised PWM");
-  return std::make_shared<Pwm>(logger, period_file, duty_cycle_file, polarity_file, enable_file);
+  return std::make_shared<Pwm>(logger, period, period_file, duty_cycle_file, enable_file);
 }
 
 Pwm::Pwm(core::ILogger &logger,
+         const std::uint32_t period,
          const int period_file,
          const int duty_cycle_file,
-         const int polarity_file,
          const int enable_file)
     : logger_(logger),
-      period_file_(period_file),
-      duty_cycle_file_(duty_cycle_file),
-      polarity_file_(polarity_file),
-      enable_file_(enable_file),
+      current_period_(period),
+      current_duty_cycle_(0),
       current_time_active_(0),
-      current_period_(0),
       current_mode_(Mode::kStop),
-      current_polarity_(Polarity::kActiveHigh)
+      duty_cycle_file_(duty_cycle_file),
+      enable_file_(enable_file)
 {
 }
 
 Pwm::~Pwm()
 {
-  close(period_file_);
   close(duty_cycle_file_);
-  close(polarity_file_);
   close(enable_file_);
+}
+
+core::Result Pwm::setMode(const Mode mode)
+{
+  // Avoid I/O if no change is required
+  if (current_mode_ == mode) {
+    logger_.log(core::LogLevel::kDebug, "PWM mode is already set to %d, skipping I/O", mode);
+    return core::Result::kSuccess;
+  }
+  // Duty cycle cannot be 0 when running
+  if (current_duty_cycle_ == 0 && mode == Mode::kRun) {
+    logger_.log(core::LogLevel::kFatal, "Failed to run PWM, duty cycle is 0");
+    return core::Result::kFailure;
+  }
+  const std::uint8_t mode_value = static_cast<std::uint8_t>(mode);
+  char write_buffer[2];
+  snprintf(write_buffer, sizeof(write_buffer), "%d", mode_value);
+  const auto num_bytes_written = write(enable_file_, write_buffer, sizeof(write_buffer));
+  if (num_bytes_written != sizeof(write_buffer)) {
+    logger_.log(core::LogLevel::kFatal, "Failed to write to PWM enable file");
+    return core::Result::kFailure;
+  }
+  logger_.log(core::LogLevel::kDebug, "Successfully set PWM mode to %d", mode_value);
+  current_mode_ = mode;
+  return core::Result::kSuccess;
 }
 
 core::Result Pwm::setDutyCycleByPercentage(const core::Float duty_cycle)
 {
+  // Duty cycle cannot be set when running
+  if (current_mode_ == Mode::kRun) {
+    logger_.log(core::LogLevel::kFatal, "Failed to set duty cycle, PWM is running");
+    return core::Result::kFailure;
+  }
   if (duty_cycle > 1.0) {
     logger_.log(core::LogLevel::kFatal,
                 "Failed to set duty cycle, percentage cannot be greater than 1.0");
     return core::Result::kFailure;
   }
-  if (duty_cycle < 0.0) {
+  if (duty_cycle <= 0.0) {
     logger_.log(core::LogLevel::kFatal,
-                "Failed to set duty cycle, percentage cannot be less than 0.0");
+                "Failed to set duty cycle, percentage cannot be less than or equal to 0.0");
     return core::Result::kFailure;
   }
   const auto time_active = static_cast<std::uint32_t>(duty_cycle * current_period_);
@@ -79,12 +120,6 @@ core::Result Pwm::setDutyCycleByPercentage(const core::Float duty_cycle)
 
 core::Result Pwm::setDutyCycleByTime(const std::uint32_t time_active)
 {
-  // Ensure active time is less or equal to period
-  if (time_active > current_period_) {
-    logger_.log(core::LogLevel::kFatal,
-                "Failed to set duty cycle, active time cannot be greater than period");
-    return core::Result::kFailure;
-  }
   // Avoid I/O if no change is required
   if (time_active == current_time_active_) {
     logger_.log(
@@ -103,63 +138,24 @@ core::Result Pwm::setDutyCycleByTime(const std::uint32_t time_active)
   return core::Result::kSuccess;
 }
 
-core::Result Pwm::setPeriod(const std::uint32_t period)
+core::Result Pwm::setPeriod(const std::uint32_t period, const int period_file)
 {
-  // Avoid I/O if no change is required
-  if (current_period_ == period) {
-    logger_.log(core::LogLevel::kDebug, "PWM period is already set to %d, skipping I/O", period);
-    return core::Result::kSuccess;
-  }
   char write_buffer[10];
-  snprintf(write_buffer, sizeof(write_buffer), "%d", current_period_);
-  const auto num_bytes_written = write(period_file_, write_buffer, sizeof(write_buffer));
-  if (num_bytes_written != sizeof(write_buffer)) {
-    logger_.log(core::LogLevel::kFatal, "Failed to write to PWM period file");
-    return core::Result::kFailure;
-  }
-  logger_.log(core::LogLevel::kDebug, "Successfully set PWM period to %d", current_period_);
-  current_period_ = period;
+  snprintf(write_buffer, sizeof(write_buffer), "%d", period);
+  const auto num_bytes_written = write(period_file, write_buffer, sizeof(write_buffer));
+  if (num_bytes_written != sizeof(write_buffer)) { return core::Result::kFailure; }
+  close(period_file);
   return core::Result::kSuccess;
 }
 
-core::Result Pwm::setPolarity(const Polarity polarity)
+core::Result Pwm::setPolarity(const Polarity polarity, const int polarity_file)
 {
-  // Avoid I/O if no change is required
-  if (current_polarity_ == polarity) {
-    logger_.log(
-      core::LogLevel::kDebug, "PWM polarity is already set to %d, skipping I/O", polarity);
-    return core::Result::kSuccess;
-  };
-  const std::uint8_t polarity_value = static_cast<std::uint8_t>(current_polarity_);
+  const std::uint8_t polarity_value = static_cast<std::uint8_t>(polarity);
   char write_buffer[2];
   snprintf(write_buffer, sizeof(write_buffer), "%d", polarity_value);
-  const auto num_bytes_written = write(polarity_file_, write_buffer, sizeof(write_buffer));
-  if (num_bytes_written != sizeof(write_buffer)) {
-    logger_.log(core::LogLevel::kFatal, "Failed to write to PWM polarity file");
-    return core::Result::kFailure;
-  }
-  logger_.log(core::LogLevel::kDebug, "Successfully set PWM polarity to %d", polarity_value);
-  current_polarity_ = polarity;
-  return core::Result::kSuccess;
-}
-
-core::Result Pwm::setMode(const Mode mode)
-{
-  // Avoid I/O if no change is required
-  if (current_mode_ == mode) {
-    logger_.log(core::LogLevel::kDebug, "PWM mode is already set to %d, skipping I/O", mode);
-    return core::Result::kSuccess;
-  }
-  const std::uint8_t mode_value = static_cast<std::uint8_t>(mode);
-  char write_buffer[2];
-  snprintf(write_buffer, sizeof(write_buffer), "%d", mode_value);
-  const auto num_bytes_written = write(enable_file_, write_buffer, sizeof(write_buffer));
-  if (num_bytes_written != sizeof(write_buffer)) {
-    logger_.log(core::LogLevel::kFatal, "Failed to write to PWM enable file");
-    return core::Result::kFailure;
-  }
-  logger_.log(core::LogLevel::kDebug, "Successfully set PWM mode to %d", mode_value);
-  current_mode_ = mode;
+  const auto num_bytes_written = write(polarity_file, write_buffer, sizeof(write_buffer));
+  if (num_bytes_written != sizeof(write_buffer)) { return core::Result::kFailure; }
+  close(polarity_file);
   return core::Result::kSuccess;
 }
 

--- a/lib/io/pwm.hpp
+++ b/lib/io/pwm.hpp
@@ -25,19 +25,30 @@ enum class Mode { kStop = 0, kRun };
 
 // use this class if a high‐frequency periodic switching signal is required
 // PWM can achieve frequencies of 1 MHz or higher, without a significant CPU load
+// PWM can have a variable duty cycle but the period and polarity is fixed
 class Pwm {
  public:
   /**
    * @brief Creates a PWM object and gets all the relevant file descriptors to do I/O operations
    */
   static std::optional<std::shared_ptr<Pwm>> create(core::ILogger &logger,
-                                                    const PwmModule pwm_module);
+                                                    const PwmModule pwm_module,
+                                                    const std::uint32_t period,
+                                                    const Polarity polarity);
   Pwm(core::ILogger &logger,
+      const std::uint32_t period,
       const int period_file,
       const int duty_cycle_file,
-      const int polarity_file,
       const int enable_file);
   ~Pwm();
+
+  /**
+   * @brief Set the mode of the PWM signal
+   * @param mode the mode of the PWM signal
+   * Mode is either stop or run
+   * @return kSuccess if the mode was set successfully
+   */
+  core::Result setMode(const Mode mode);
 
   /**
    * @brief Set the duty cycle of the PWM signal using a percentage
@@ -47,6 +58,7 @@ class Pwm {
    */
   core::Result setDutyCycleByPercentage(const core::Float duty_cycle);
 
+ private:
   /**
    * @brief Set the duty cycle of the PWM signal using a value for active time
    * @param time_active the length of time the PWM signal is "active" in ns
@@ -60,7 +72,7 @@ class Pwm {
    * @param period the period of the PWM signal in ns
    * @return kSuccess if the period was set successfully
    */
-  core::Result setPeriod(const std::uint32_t period);
+  static core::Result setPeriod(const std::uint32_t period, const int period_file);
 
   /**
    * @brief Set the polarity of the PWM signal
@@ -68,17 +80,8 @@ class Pwm {
    * Polarity is either active high or active low
    * @return kSuccess if the polarity was set successfully
    */
-  core::Result setPolarity(const Polarity polarity);
+  static core::Result setPolarity(const Polarity polarity, const int polarity_file);
 
-  /**
-   * @brief Set the mode of the PWM signal
-   * @param mode the mode of the PWM signal
-   * Mode is either stop or run
-   * @return kSuccess if the mode was set successfully
-   */
-  core::Result setMode(const Mode mode);
-
- private:
   /**
    * @brief Get the corect folder name for the chosen PWM module
    * @param pwm_module the PWM module to get the folder name for
@@ -86,14 +89,14 @@ class Pwm {
    */
   static std::string getPwmFolderName(const PwmModule pwm_module);
 
+ private:
   core::ILogger &logger_;
+  core::Float current_duty_cycle_;
   std::uint32_t current_time_active_;  // ns
   std::uint32_t current_period_;       // ns
   Mode current_mode_;
   Polarity current_polarity_;
-  int period_file_;
   int duty_cycle_file_;
-  int polarity_file_;
   int enable_file_;
 };
 


### PR DESCRIPTION
- [x] Fixed GPIO alt
- [x] Fixed PWM 

PWM on the bbb must be set up in the order: period, polarity, duty cycle, enable. We only ever need to manipulate duty cycle, so I've enforced this.