### PR TITLE
MTC - CAN Extended support

### DIFF
--- a/lib/io/can.hpp
+++ b/lib/io/can.hpp
@@ -37,6 +37,7 @@ struct sockaddr_can {
 #define AF_CAN 29
 #define CAN_RAW 1
 #define CAN_MAX_DLEN 8
+#define CAN_EFF_FLAG 0x80000000U  // EFF/SFF is set in the MSB
 #endif
 
 class ICanProcessor {


### PR DESCRIPTION
I believe socket automatically deals with extended CAN IDs, all that needs to change is to OR the ID in the sent frame with the CAN_EFF_FLAG.
Added the CAN_EFF_FLAG define for non linux systems

TODO:

- [x] Test socket actually handles it