### PR TITLE
MTC - CAN return processor errors + documentation

### DIFF
--- a/lib/io/can.hpp
+++ b/lib/io/can.hpp
@@ -41,13 +41,44 @@ struct sockaddr_can {
 
 class ICanProcessor {
  public:
-  virtual void processMessage(const io::CanFrame &frame) = 0;
+  /**
+   * @brief Called by ICan::receive() when a message with the given ID is received
+   * @param frame The CAN message to be processed
+   * @return core::Result::kSuccess if the message was processed successfully,
+   * core::Result::kFailure otherwise
+   */
+  virtual core::Result processMessage(const io::CanFrame &frame) = 0;
 };
 
 class ICan {
  public:
-  virtual core::Result send(const CanFrame &message)                                          = 0;
-  virtual core::Result receive()                                                              = 0;
+  /**
+   * @brief Send a CAN message
+   * @param message The message to be sent
+   * @return core::Result::kSuccess if the message was sent successfully core::Result::kFailure
+   * otherwise
+   * @note To send an extended CAN message, set the EFF flag in the can_id field by ORing it with
+   * CAN_EFF_FLAG
+   */
+  virtual core::Result send(const CanFrame &message) = 0;
+
+  /**
+   * @brief Attempt to receive a CAN message
+   * @return core::Result::kSuccess if a message was received and successfully processed by all
+   * registered processors, core::Result::kFailure if a message is not received successfully or if a
+   * message is received but not processed by all registered processors
+   * @note If a message is received then the message will be processed by all processors registered
+   * to that ID
+   * @note If the message is an extended CAN message, the EFF flag will be set in the can_id field
+   * and thus the actual ID will be frame.can_id - 0x80000000
+   */
+  virtual core::Result receive() = 0;
+
+  /**
+   * @brief Registers a processor to be called when a message with the given ID is received
+   * @param id The ID of the message to be processed
+   * @param processor The processor to be called when a message with the given ID is received
+   */
   virtual void addProcessor(const std::uint16_t id, std::shared_ptr<ICanProcessor> processor) = 0;
 };
 }  // namespace hyped::io

--- a/lib/io/can.hpp
+++ b/lib/io/can.hpp
@@ -42,7 +42,8 @@ struct sockaddr_can {
 class ICanProcessor {
  public:
   /**
-   * @brief Called by ICan::receive() when a message with the given ID is received
+   * @brief Called by ICan::receive() when a message with the given ID is received. What it then
+   * does with the frame is up to the implementation
    * @param frame The CAN message to be processed
    * @return core::Result::kSuccess if the message was processed successfully,
    * core::Result::kFailure otherwise

--- a/lib/io/hardware_can.cpp
+++ b/lib/io/hardware_can.cpp
@@ -109,12 +109,11 @@ core::Result HardwareCan::receive()
     logger_.log(core::LogLevel::kFatal, "No CanProccessor associated with id %i", message.can_id);
     return core::Result::kFailure;
   }
-  core::Result process_successful = core::Result::kSuccess;
   for (auto &processor : subscribed_processors->second) {
     core::Result process_result = processor->processMessage(message);
-    if (process_result == core::Result::kFailure) { process_successful = core::Result::kFailure; }
+    if (process_result == core::Result::kFailure) { return core::Result::kFailure; }
   }
-  return process_successful;
+  return core::Result::kSuccess;
 }
 
 void HardwareCan::addProcessor(const std::uint16_t id, std::shared_ptr<ICanProcessor> processor)

--- a/lib/io/hardware_can.cpp
+++ b/lib/io/hardware_can.cpp
@@ -109,10 +109,12 @@ core::Result HardwareCan::receive()
     logger_.log(core::LogLevel::kFatal, "No CanProccessor associated with id %i", message.can_id);
     return core::Result::kFailure;
   }
+  core::Result process_successful = core::Result::kSuccess;
   for (auto &processor : subscribed_processors->second) {
-    processor->processMessage(message);
+    core::Result process_result = processor->processMessage(message);
+    if (process_result == core::Result::kFailure) { process_successful = core::Result::kFailure; }
   }
-  return core::Result::kSuccess;
+  return process_successful;
 }
 
 void HardwareCan::addProcessor(const std::uint16_t id, std::shared_ptr<ICanProcessor> processor)

--- a/lib/io/hardware_can.hpp
+++ b/lib/io/hardware_can.hpp
@@ -15,12 +15,44 @@ namespace hyped::io {
 
 class HardwareCan : public ICan {
  public:
+  /**
+   * @brief Construct a new Hardware Can object
+   *
+   * @param can_network_interface The name of the CAN network interface to use
+   * @return std::shared_ptr<HardwareCan> if successful, std::nullopt otherwise
+   */
   static std::optional<std::shared_ptr<HardwareCan>> create(
     core::ILogger &logger, const std::string &can_network_interface);
   HardwareCan(core::ILogger &logger, const int socket);
   ~HardwareCan();
+
+  /**
+   * @brief Send a CAN message
+   * @param message The message to be sent
+   * @return core::Result::kSuccess if the message was sent successfully core::Result::kFailure
+   * otherwise
+   * @note To send an extended CAN message, set the EFF flag in the can_id field by ORing it with
+   * CAN_EFF_FLAG
+   */
   core::Result send(const CanFrame &message);
+
+  /**
+   * @brief Attempt to receive a CAN message
+   * @return core::Result::kSuccess if a message was received and successfully processed by all
+   * registered processors, core::Result::kFailure if a message is not received successfully or if a
+   * message is received but not processed by all registered processors
+   * @note If a message is received then the message will be processed by all processors registered
+   * to that ID
+   * @note If the message is an extended CAN message, the EFF flag will be set in the can_id field
+   * and thus the actual ID will be frame.can_id - 0x80000000
+   */
   core::Result receive();
+
+  /**
+   * @brief Registers a processor to be called when a message with the given ID is received
+   * @param id The ID of the message to be processed
+   * @param processor The processor to be called when a message with the given ID is received
+   */
   void addProcessor(const std::uint16_t id, std::shared_ptr<ICanProcessor> processor);
 
  private:

--- a/lib/motors/can_processor.cpp
+++ b/lib/motors/can_processor.cpp
@@ -10,7 +10,7 @@ CanProcessor::CanProcessor()
 core::Result CanProcessor::processMessage(const io::CanFrame &frame)
 {
   // TODOLater implement
-  return;
+  return core::Result::kFailure;
 }
 
 }  // namespace hyped::motors

--- a/lib/motors/can_processor.cpp
+++ b/lib/motors/can_processor.cpp
@@ -7,7 +7,7 @@ CanProcessor::CanProcessor()
   // TODOLater implement
 }
 
-void CanProcessor::processMessage(const io::CanFrame &frame)
+core::Result CanProcessor::processMessage(const io::CanFrame &frame)
 {
   // TODOLater implement
   return;

--- a/lib/motors/can_processor.hpp
+++ b/lib/motors/can_processor.hpp
@@ -11,7 +11,7 @@ class CanProcessor : public io::ICanProcessor {
  public:
   CanProcessor();
 
-  void processMessage(const io::CanFrame &frame);
+  core::Result processMessage(const io::CanFrame &frame);
 };
 
 }  // namespace hyped::motors


### PR DESCRIPTION
Changed CanProcessor and ICanProcessor to return `core::Result::kFailure` if a processor fails to process its message

Also added doc comments to CAN classes