### PR TITLE
feat(tel): Write telemetry data and show historical data

### DIFF
--- a/telemetry/packages/constants/src/index.ts
+++ b/telemetry/packages/constants/src/index.ts
@@ -1,2 +1,2 @@
 export { pods, POD_IDS } from './pods/pods';
-export { objectTypes } from './object-types/object-types';
+export { openMctObjectTypes } from './openmct/object-types/object-types';

--- a/telemetry/packages/constants/src/object-types/object-types.types.ts
+++ b/telemetry/packages/constants/src/object-types/object-types.types.ts
@@ -1,7 +1,0 @@
-export type ObjectType = {
-  id: string;
-  name: string;
-  icon: string;
-}
-
-export type ObjectTypes =ObjectType[];

--- a/telemetry/packages/constants/src/openmct/object-types/object-types.ts
+++ b/telemetry/packages/constants/src/openmct/object-types/object-types.ts
@@ -1,4 +1,4 @@
-import { OpenMctObjectTypes } from "@hyped/telemetry-types";
+import type { OpenMctObjectTypes } from "@hyped/telemetry-types";
 
 export const openMctObjectTypes: OpenMctObjectTypes = [
   {

--- a/telemetry/packages/constants/src/openmct/object-types/object-types.ts
+++ b/telemetry/packages/constants/src/openmct/object-types/object-types.ts
@@ -1,6 +1,6 @@
-import { ObjectTypes } from './object-types.types';
+import { OpenMctObjectTypes } from "@hyped/telemetry-types";
 
-export const objectTypes: ObjectTypes = [
+export const openMctObjectTypes: OpenMctObjectTypes = [
   {
     id: 'temperature',
     name: 'Temperature',

--- a/telemetry/packages/constants/src/pods/pods.ts
+++ b/telemetry/packages/constants/src/pods/pods.ts
@@ -70,12 +70,12 @@ export const pods: Pods = {
         unit: 'brakes engaged',
         enumerations: [
           {
-            key: 'ON',
-            value: '1',
+            value: 1,
+            string: 'ON',
           },
           {
-            key: 'OFF',
-            value: '0',
+            value: 0,
+            string: 'OFF',
           },
         ],
       },
@@ -148,12 +148,12 @@ export const pods: Pods = {
         unit: 'brakes engaged',
         enumerations: [
           {
-            key: 'ON',
-            value: '1',
+            value: 1,
+            string: 'ON',
           },
           {
-            key: 'OFF',
-            value: '0',
+            value: 0,
+            string: 'OFF',
           },
         ],
       },

--- a/telemetry/packages/constants/src/pods/pods.ts
+++ b/telemetry/packages/constants/src/pods/pods.ts
@@ -1,10 +1,11 @@
-import { POD_IDS, Pods } from '@hyped/telemetry-types';
+import type { Pods } from '@hyped/telemetry-types';
 
-export { POD_IDS };
+export const POD_IDS = ['1', '2'] as const;
+
 export const pods: Pods = {
   '1': {
     name: 'Pod 1',
-    podId: 1,
+    id: 1,
     measurements: {
       'temperature.shell_front': {
         name: 'Temperature - Shell Front',
@@ -82,7 +83,7 @@ export const pods: Pods = {
   },
   '2': {
     name: 'Pod 2',
-    podId: 2,
+    id: 2,
     measurements: {
       'temperature.shell_front': {
         name: 'Temperature - Shell Front',

--- a/telemetry/packages/constants/src/pods/pods.ts
+++ b/telemetry/packages/constants/src/pods/pods.ts
@@ -4,7 +4,85 @@ export { POD_IDS };
 export const pods: Pods = {
   '1': {
     name: 'Pod 1',
-    key: 'pod.1',
+    podId: 1,
+    measurements: {
+      'temperature.shell_front': {
+        name: 'Temperature - Shell Front',
+        key: 'temperature.shell_front',
+        format: 'float',
+        type: 'temperature',
+        unit: '°C',
+        range: {
+          min: -20,
+          max: 50,
+        },
+      },
+      'temperature.shell_middle': {
+        name: 'Temperature - Shell Middle',
+        key: 'temperature.shell_middle',
+        format: 'float',
+        type: 'temperature',
+        unit: '°C',
+        range: {
+          min: -20,
+          max: 50,
+        },
+      },
+      'temperature.shell_back': {
+        name: 'Temperature - Shell Back',
+        key: 'temperature.shell_back',
+        format: 'float',
+        type: 'temperature',
+        unit: '°C',
+        range: {
+          min: -20,
+          max: 50,
+        },
+      },
+      accelerometer: {
+        name: 'Accelerometer',
+        key: 'accelerometer',
+        format: 'float',
+        type: 'acceleration',
+        unit: 'ms^-2',
+        range: {
+          min: -10,
+          max: 10,
+        },
+      },
+      keyence: {
+        name: 'Keyence',
+        key: 'keyence',
+        format: 'integer',
+        type: 'keyence',
+        unit: 'number of stripes',
+        range: {
+          min: 0,
+          max: 100,
+        },
+      },
+      brake_feedback: {
+        name: 'Brake Feedback',
+        key: 'brake_feedback',
+        format: 'enum',
+        type: 'brake_feedback',
+        unit: 'brakes engaged',
+        enumerations: [
+          {
+            key: 'ON',
+            value: "1",
+          },
+          {
+            key: 'OFF',
+            value: "0",
+          },
+        ],
+      },
+    },
+  },
+  '2': {
+    name: 'Pod 2',
+    podId: 2,
     measurements: {
       'temperature.shell_front': {
         name: 'Temperature - Shell Front',

--- a/telemetry/packages/constants/src/pods/pods.ts
+++ b/telemetry/packages/constants/src/pods/pods.ts
@@ -1,4 +1,4 @@
-import { Pods, POD_IDS } from "./pods.types";
+import { POD_IDS, Pods } from '@hyped/telemetry-types';
 
 export { POD_IDS };
 export const pods: Pods = {
@@ -70,11 +70,11 @@ export const pods: Pods = {
         enumerations: [
           {
             key: 'ON',
-            value: "1",
+            value: '1',
           },
           {
             key: 'OFF',
-            value: "0",
+            value: '0',
           },
         ],
       },
@@ -148,11 +148,11 @@ export const pods: Pods = {
         enumerations: [
           {
             key: 'ON',
-            value: "1",
+            value: '1',
           },
           {
             key: 'OFF',
-            value: "0",
+            value: '0',
           },
         ],
       },

--- a/telemetry/packages/constants/src/pods/pods.types.ts
+++ b/telemetry/packages/constants/src/pods/pods.types.ts
@@ -1,4 +1,4 @@
-export const POD_IDS = ['1'] as const;
+export const POD_IDS = ['1', '2'] as const;
 
 export type BaseMeasurement = {
   name: string;
@@ -27,7 +27,7 @@ export type Measurement = RangeMeasurement | EnumMeasurement;
 
 export type Pod = {
   name: string;
-  key: string;
+  podId: number;
   measurements: Record<string, Measurement>;
 }
 

--- a/telemetry/packages/server/fake/fake-data.ts
+++ b/telemetry/packages/server/fake/fake-data.ts
@@ -2,7 +2,7 @@
 import mqtt from 'mqtt';
 import random from 'random';
 import { pods } from '@hyped/telemetry-constants';
-import { Measurement } from '@hyped/telemetry-constants/dist/pods/pods.types';
+import { Measurement } from '@hyped/telemetry-types';
 
 const client = mqtt.connect('mqtt://localhost:1883');
 

--- a/telemetry/packages/server/package.json
+++ b/telemetry/packages/server/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@hyped/telemetry-constants": "*",
+    "@hyped/telemetry-types": "*",
     "@influxdata/influxdb-client": "^1.33.1",
     "@nestjs/common": "^9.2.1",
     "@nestjs/core": "^9.2.1",

--- a/telemetry/packages/server/src/app.module.ts
+++ b/telemetry/packages/server/src/app.module.ts
@@ -6,6 +6,7 @@ import { LoggerModule } from './modules/logger/Logger.module';
 import { MqttClientModule } from './modules/mqtt/client/MqttClientModule';
 import { MqttIngestionModule } from './modules/mqtt/ingestion/MqttIngestion.module';
 import { OpenMCTModule } from './modules/openmct/OpenMCT.module';
+import { MeasurementModule } from './modules/measurement/Measurement.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { OpenMCTModule } from './modules/openmct/OpenMCT.module';
     InfluxModule,
     MqttIngestionModule,
     OpenMCTModule,
+    MeasurementModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/telemetry/packages/server/src/modules/influx/Influx.service.ts
+++ b/telemetry/packages/server/src/modules/influx/Influx.service.ts
@@ -29,4 +29,12 @@ export class InfluxService implements OnModuleInit {
       throw new Error('InfluxDB query API not initialized');
     }
   }
+
+  async onModuleDestroy() {
+    try {
+      await this.write.close();
+    } catch (e) {
+      console.error(e);
+    }
+  }
 }

--- a/telemetry/packages/server/src/modules/measurement/Measurement.module.ts
+++ b/telemetry/packages/server/src/modules/measurement/Measurement.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { MeasurementService } from './Measurement.service';
+import { InfluxModule } from '../influx/Influx.module';
+
+@Module({
+  imports: [InfluxModule],
+  providers: [MeasurementService],
+  exports: [MeasurementService],
+})
+export class MeasurementModule {}

--- a/telemetry/packages/server/src/modules/measurement/Measurement.service.ts
+++ b/telemetry/packages/server/src/modules/measurement/Measurement.service.ts
@@ -43,12 +43,20 @@ export class MeasurementService {
       .tag('format', measurement.format)
       .floatField('value', value);
 
-    this.influxService.write.writePoint(point);
+    try {
+      this.influxService.write.writePoint(point);
 
-    this.logger.verbose(
-      `Added measurement {${props.podId}/${props.measurementKey}}: ${props.value}`,
-      MeasurementService.name,
-    );
+      this.logger.verbose(
+        `Added measurement {${props.podId}/${props.measurementKey}}: ${props.value}`,
+        MeasurementService.name,
+      );
+    } catch (e) {
+      this.logger.error(
+        `Failed to add measurement {${props.podId}/${props.measurementKey}}: ${props.value}`,
+        e,
+        MeasurementService.name,
+      );
+    }
   }
 
   private logValidationError(message: string, props: MeasurementReading) {

--- a/telemetry/packages/server/src/modules/measurement/Measurement.service.ts
+++ b/telemetry/packages/server/src/modules/measurement/Measurement.service.ts
@@ -1,0 +1,99 @@
+import { pods } from '@hyped/telemetry-constants';
+import { Point } from '@influxdata/influxdb-client';
+import { Injectable, LoggerService } from '@nestjs/common';
+import { z } from 'zod';
+import { InfluxService } from '../influx/Influx.service';
+import { Logger } from '../logger/Logger.decorator';
+
+const BaseMeasurementReading = z.object({
+  podId: z.string(),
+  measurementKey: z.string(),
+  value: z.number(),
+});
+
+type MeasurementReading = z.infer<typeof BaseMeasurementReading>;
+
+@Injectable()
+export class MeasurementService {
+  constructor(
+    @Logger()
+    private readonly logger: LoggerService,
+    private influxService: InfluxService,
+  ) {}
+
+  public addMeasurement(props: MeasurementReading) {
+    const currentTime = new Date();
+
+    const validatedMeasurement = this.validateMeasurementReading(props);
+
+    if (!validatedMeasurement) {
+      // do something more here...maybe
+      return;
+    }
+
+    const {
+      measurement,
+      reading: { podId, measurementKey, value },
+    } = validatedMeasurement;
+
+    const point = new Point('measurement')
+      .timestamp(currentTime)
+      .tag('podId', podId)
+      .tag('measurementKey', measurementKey)
+      .tag('format', measurement.format)
+      .floatField('value', value);
+
+    this.influxService.write.writePoint(point);
+
+    this.logger.verbose(
+      `Added measurement {${props.podId}/${props.measurementKey}}: ${props.value}`,
+      MeasurementService.name,
+    );
+  }
+
+  private logValidationError(message: string, props: MeasurementReading) {
+    this.logger.error(
+      `${message} {${props.podId ?? 'unknownPod'}/${
+        props.measurementKey ?? 'unknownMeasurement'
+      }}: ${props.value ?? 'no value'}`,
+      null,
+      MeasurementService.name,
+    );
+  }
+
+  private validateMeasurementReading(props: MeasurementReading) {
+    const result = BaseMeasurementReading.safeParse(props);
+    if (!result.success) {
+      this.logValidationError('Invalid measurement reading', props);
+      return;
+    }
+
+    const { podId, measurementKey, value } = result.data;
+
+    const pod = pods[podId];
+    if (!pod) {
+      this.logValidationError('Pod not found', props);
+      return;
+    }
+
+    const measurement = pods[podId]['measurements'][measurementKey];
+    if (!measurement) {
+      this.logValidationError('Measurement not found', props);
+      return;
+    }
+
+    if (measurement.format === 'enum') {
+      const enumValue = measurement.enumerations.find((e) => e.value === value);
+
+      if (!enumValue) {
+        this.logValidationError('Invalid enum value', props);
+        return;
+      }
+    }
+
+    return {
+      reading: result.data,
+      measurement,
+    };
+  }
+}

--- a/telemetry/packages/server/src/modules/mqtt/ingestion/MqttIngestion.module.ts
+++ b/telemetry/packages/server/src/modules/mqtt/ingestion/MqttIngestion.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { MqttIngestionService } from './MqttIngestion.service';
+import { MeasurementModule } from 'src/modules/measurement/Measurement.module';
 
 @Module({
+  imports: [MeasurementModule],
   providers: [MqttIngestionService],
 })
 export class MqttIngestionModule {}

--- a/telemetry/packages/server/src/modules/mqtt/ingestion/MqttIngestion.service.ts
+++ b/telemetry/packages/server/src/modules/mqtt/ingestion/MqttIngestion.service.ts
@@ -1,15 +1,10 @@
-import { Injectable, LoggerService } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Params, Payload, Subscribe } from 'nest-mqtt';
-import { Logger } from 'src/modules/logger/Logger.decorator';
 import { MeasurementService } from 'src/modules/measurement/Measurement.service';
 
 @Injectable()
 export class MqttIngestionService {
-  constructor(
-    @Logger()
-    private readonly logger: LoggerService,
-    private measurementService: MeasurementService,
-  ) {}
+  constructor(private measurementService: MeasurementService) {}
 
   @Subscribe('hyped/+/+')
   getNotifications(@Params() rawParams: string[], @Payload() rawValue: any) {

--- a/telemetry/packages/server/src/modules/mqtt/ingestion/MqttIngestion.service.ts
+++ b/telemetry/packages/server/src/modules/mqtt/ingestion/MqttIngestion.service.ts
@@ -1,59 +1,22 @@
-import { pods, POD_IDS } from '@hyped/telemetry-constants';
 import { Injectable, LoggerService } from '@nestjs/common';
-import { Params, Payload, Subscribe, Topic } from 'nest-mqtt';
+import { Params, Payload, Subscribe } from 'nest-mqtt';
 import { Logger } from 'src/modules/logger/Logger.decorator';
-import { z } from 'zod';
-
-const MqttMessage = z.object({
-  podId: z.enum(POD_IDS),
-  measurementName: z.string(),
-  value: z.coerce.string(),
-});
+import { MeasurementService } from 'src/modules/measurement/Measurement.service';
 
 @Injectable()
 export class MqttIngestionService {
   constructor(
     @Logger()
     private readonly logger: LoggerService,
+    private measurementService: MeasurementService,
   ) {}
 
   @Subscribe('hyped/+/+')
-  getNotifications(
-    @Topic() rawTopic: string,
-    @Params() rawParams: string[],
-    @Payload() rawValue: any,
-  ) {
-    const result = MqttMessage.safeParse({
-      podId: rawParams[0],
-      measurementName: rawParams[1],
-      value: rawValue,
-    });
+  getNotifications(@Params() rawParams: string[], @Payload() rawValue: any) {
+    const podId = rawParams[0];
+    const measurementKey = rawParams[1];
+    const value = rawValue;
 
-    if (!result.success) {
-      this.logger.error(
-        `Invalid MQTT message {${rawTopic}}: ${result.error.message}`,
-        null,
-        MqttIngestionService.name,
-      );
-      return;
-    }
-
-    const { podId, measurementName, value } = result.data;
-
-    const measurement = pods[podId]['measurements'][measurementName];
-
-    if (!measurement) {
-      this.logger.error(
-        `Invalid MQTT message {${rawTopic}}: Measurement not found`,
-        null,
-        MqttIngestionService.name,
-      );
-      return;
-    }
-
-    this.logger.debug(
-      `Incoming measurement reading {${measurement.name}}: ${value}}`,
-      MqttIngestionService.name,
-    );
+    this.measurementService.addMeasurement({ podId, measurementKey, value });
   }
 }

--- a/telemetry/packages/server/src/modules/openmct/OpenMCT.module.ts
+++ b/telemetry/packages/server/src/modules/openmct/OpenMCT.module.ts
@@ -3,8 +3,10 @@ import { DictionaryController } from './dictionary/Dictionary.controller';
 import { DictionaryService } from './dictionary/Dictionary.service';
 import { ObjectTypesController } from './object-types/ObjectTypes.controller';
 import { ObjectTypesService } from './object-types/ObjectTypes.service';
+import { OpenMCTDataModule } from './data/OpenMCTData.module';
 
 @Module({
+  imports: [OpenMCTDataModule],
   controllers: [DictionaryController, ObjectTypesController],
   providers: [DictionaryService, ObjectTypesService],
 })

--- a/telemetry/packages/server/src/modules/openmct/data/OpenMCTData.module.ts
+++ b/telemetry/packages/server/src/modules/openmct/data/OpenMCTData.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { HistoricalDataController } from './historical/HistoricalData.controller';
+import { HistoricalDataService } from './historical/HistoricalData.service';
+import { InfluxModule } from 'src/modules/influx/Influx.module';
+
+@Module({
+  imports: [InfluxModule],
+  controllers: [HistoricalDataController],
+  providers: [HistoricalDataService],
+})
+export class OpenMCTDataModule {}

--- a/telemetry/packages/server/src/modules/openmct/data/historical/HistoricalData.controller.ts
+++ b/telemetry/packages/server/src/modules/openmct/data/historical/HistoricalData.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { HistoricalDataService } from './HistoricalData.service';
+
+@Controller('openmct/data/historical')
+export class HistoricalDataController {
+  constructor(private historicalDataService: HistoricalDataService) {}
+  @Get('pods/:podId/measurements/:measurementKey')
+  getHistoricalReading(
+    @Param('podId') podId: string,
+    @Param('measurementKey') measurementKey: string,
+    @Query('start') start: string,
+    @Query('end') end: string,
+  ) {
+    return this.historicalDataService.getHistoricalReading(
+      podId,
+      measurementKey,
+      start,
+      end,
+    );
+  }
+}

--- a/telemetry/packages/server/src/modules/openmct/data/historical/HistoricalData.service.ts
+++ b/telemetry/packages/server/src/modules/openmct/data/historical/HistoricalData.service.ts
@@ -1,0 +1,58 @@
+import { flux, fluxDateTime } from '@influxdata/influxdb-client';
+import { Injectable, LoggerService } from '@nestjs/common';
+import { INFLUX_BUCKET } from '@/core/config';
+import { InfluxService } from '@/modules/influx/Influx.service';
+import { Logger } from '@/modules/logger/Logger.decorator';
+
+type InfluxRow = {
+  _time: string;
+  _value: string;
+  measurementKey: string;
+  podId: string;
+  format: string;
+};
+
+@Injectable()
+export class HistoricalDataService {
+  constructor(
+    private influxService: InfluxService,
+    @Logger()
+    private readonly logger: LoggerService,
+  ) {}
+
+  public async getHistoricalReading(
+    podId: string,
+    measurementKey: string,
+    startTimestamp: string,
+    endTimestamp: string,
+  ) {
+    const fluxStart = fluxDateTime(
+      new Date(parseInt(startTimestamp)).toISOString(),
+    );
+    const fluxEnd = fluxDateTime(
+      new Date(parseInt(endTimestamp)).toISOString(),
+    );
+
+    const query = flux`
+      from(bucket: "${INFLUX_BUCKET}")
+        |> range(start: ${fluxStart}, stop: ${fluxEnd})
+        |> filter(fn: (r) => r["measurementKey"] == "${measurementKey}")
+        |> filter(fn: (r) => r["podId"] == "${podId}")`;
+
+    try {
+      const data = await this.influxService.query.collectRows<InfluxRow>(query);
+
+      return data.map((row) => ({
+        id: row['measurementKey'],
+        timestamp: new Date(row['_time']).getTime(),
+        value: row['_value'],
+      }));
+    } catch (e) {
+      this.logger.error(
+        `Failed to get historical reading for {${podId}/${measurementKey}}`,
+        e,
+        HistoricalDataService.name,
+      );
+    }
+  }
+}

--- a/telemetry/packages/server/src/modules/openmct/dictionary/Dictionary.controller.ts
+++ b/telemetry/packages/server/src/modules/openmct/dictionary/Dictionary.controller.ts
@@ -1,13 +1,20 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Param } from '@nestjs/common';
 import { DictionaryService } from './Dictionary.service';
 
 @Controller('openmct/dictionary')
 export class DictionaryController {
   constructor(private dictionaryService: DictionaryService) {}
 
-  @Get()
-  getDictionary() {
-    const pods = this.dictionaryService.getDictionary();
-    return pods;
+  @Get('pods')
+  getPodIds() {
+    const podIds = this.dictionaryService.getPodIds();
+    return {
+      podIds,
+    };
+  }
+
+  @Get('pod/:podId')
+  getPod(@Param('podId') podId: string) {
+    return this.dictionaryService.getPod(podId);
   }
 }

--- a/telemetry/packages/server/src/modules/openmct/dictionary/Dictionary.controller.ts
+++ b/telemetry/packages/server/src/modules/openmct/dictionary/Dictionary.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Param } from '@nestjs/common';
 import { DictionaryService } from './Dictionary.service';
+import { OpenMctPod } from '@hyped/telemetry-types';
 
 @Controller('openmct/dictionary')
 export class DictionaryController {
@@ -7,14 +8,14 @@ export class DictionaryController {
 
   @Get('pods')
   getPodIds() {
-    const podIds = this.dictionaryService.getPodIds();
+    const ids = this.dictionaryService.getPodIds();
     return {
-      podIds,
+      ids,
     };
   }
 
   @Get('pod/:podId')
-  getPod(@Param('podId') podId: string) {
+  getPod(@Param('podId') podId: string): OpenMctPod {
     return this.dictionaryService.getPod(podId);
   }
 }

--- a/telemetry/packages/server/src/modules/openmct/dictionary/Dictionary.controller.ts
+++ b/telemetry/packages/server/src/modules/openmct/dictionary/Dictionary.controller.ts
@@ -14,7 +14,7 @@ export class DictionaryController {
     };
   }
 
-  @Get('pod/:podId')
+  @Get('pods/:podId')
   getPod(@Param('podId') podId: string): OpenMctPod {
     return this.dictionaryService.getPod(podId);
   }

--- a/telemetry/packages/server/src/modules/openmct/dictionary/Dictionary.controller.ts
+++ b/telemetry/packages/server/src/modules/openmct/dictionary/Dictionary.controller.ts
@@ -7,7 +7,7 @@ export class DictionaryController {
 
   @Get()
   getDictionary() {
-    const pod = this.dictionaryService.getDictionary();
-    return pod;
+    const pods = this.dictionaryService.getDictionary();
+    return pods;
   }
 }

--- a/telemetry/packages/server/src/modules/openmct/dictionary/Dictionary.service.ts
+++ b/telemetry/packages/server/src/modules/openmct/dictionary/Dictionary.service.ts
@@ -52,8 +52,8 @@ export class DictionaryService {
               source: 'timestamp',
               name: 'Timestamp',
               format: 'utc',
-              units: {
-                domain: 'time',
+              hints: {
+                domain: 1,
               },
             },
           ],

--- a/telemetry/packages/server/src/modules/openmct/dictionary/Dictionary.service.ts
+++ b/telemetry/packages/server/src/modules/openmct/dictionary/Dictionary.service.ts
@@ -13,7 +13,11 @@ export class DictionaryService {
     return dictionary;
   }
 
-  private getPod(podId: string): OpenMctPod {
+  getPodIds() {
+    return POD_IDS;
+  }
+
+  getPod(podId: string): OpenMctPod {
     const pod = pods[podId as keyof typeof pods];
 
     if (!pod) {

--- a/telemetry/packages/server/src/modules/openmct/dictionary/Dictionary.service.ts
+++ b/telemetry/packages/server/src/modules/openmct/dictionary/Dictionary.service.ts
@@ -59,7 +59,7 @@ export class DictionaryService {
 
     return {
       name: pod.name,
-      podId: pod.podId,
+      id: pod.id,
       measurements,
     };
   }

--- a/telemetry/packages/server/src/modules/openmct/dictionary/Dictionary.service.ts
+++ b/telemetry/packages/server/src/modules/openmct/dictionary/Dictionary.service.ts
@@ -1,20 +1,30 @@
-import { pods } from '@hyped/telemetry-constants';
+import { POD_IDS, pods } from '@hyped/telemetry-constants';
 import { Injectable } from '@nestjs/common';
 
 @Injectable()
 export class DictionaryService {
-  getDictionary(podId = '1') {
+  getDictionary() {
+    const dictionary: any = {};
+    POD_IDS.forEach((podId) => {
+      dictionary[podId] = this.getPod(podId);
+    });
+
+    return dictionary;
+  }
+
+  private getPod(podId: string) {
     const pod = pods[podId as keyof typeof pods];
 
     if (!pod) {
       throw new Error(`Pod ${podId} not found`);
     }
 
-    const dictionary = Object.entries(pod.measurements).map(
+    const measurements = Object.entries(pod.measurements).map(
       ([key, measurement]) => {
         return {
           name: measurement.name,
           key: key,
+          type: measurement.type,
           values: [
             {
               key: 'value',
@@ -48,8 +58,8 @@ export class DictionaryService {
 
     return {
       name: pod.name,
-      key: pod.key,
-      measurements: dictionary,
+      podId: pod.podId,
+      measurements,
     };
   }
 }

--- a/telemetry/packages/server/src/modules/openmct/dictionary/Dictionary.service.ts
+++ b/telemetry/packages/server/src/modules/openmct/dictionary/Dictionary.service.ts
@@ -1,9 +1,10 @@
 import { POD_IDS, pods } from '@hyped/telemetry-constants';
+import { OpenMctDictionary, OpenMctPod } from '@hyped/telemetry-types';
 import { Injectable } from '@nestjs/common';
 
 @Injectable()
 export class DictionaryService {
-  getDictionary() {
+  getDictionary(): OpenMctDictionary {
     const dictionary: any = {};
     POD_IDS.forEach((podId) => {
       dictionary[podId] = this.getPod(podId);
@@ -12,7 +13,7 @@ export class DictionaryService {
     return dictionary;
   }
 
-  private getPod(podId: string) {
+  private getPod(podId: string): OpenMctPod {
     const pod = pods[podId as keyof typeof pods];
 
     if (!pod) {

--- a/telemetry/packages/server/src/modules/openmct/dictionary/Dictionary.service.ts
+++ b/telemetry/packages/server/src/modules/openmct/dictionary/Dictionary.service.ts
@@ -5,7 +5,7 @@ import { Injectable } from '@nestjs/common';
 @Injectable()
 export class DictionaryService {
   getDictionary(): OpenMctDictionary {
-    const dictionary: any = {};
+    const dictionary: OpenMctDictionary = {};
     POD_IDS.forEach((podId) => {
       dictionary[podId] = this.getPod(podId);
     });

--- a/telemetry/packages/server/src/modules/openmct/object-types/ObjectTypes.service.ts
+++ b/telemetry/packages/server/src/modules/openmct/object-types/ObjectTypes.service.ts
@@ -1,9 +1,10 @@
-import { objectTypes } from '@hyped/telemetry-constants';
+import { openMctObjectTypes } from '@hyped/telemetry-constants';
+import { OpenMctObjectTypes } from '@hyped/telemetry-types';
 import { Injectable } from '@nestjs/common';
 
 @Injectable()
 export class ObjectTypesService {
-  getObjectTypes() {
-    return objectTypes;
+  getObjectTypes(): OpenMctObjectTypes {
+    return openMctObjectTypes;
   }
 }

--- a/telemetry/packages/server/tsconfig.json
+++ b/telemetry/packages/server/tsconfig.json
@@ -18,6 +18,14 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "resolveJsonModule": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "paths": {
+      "@/modules/*": [
+        "src/modules/*",
+    ],
+      "@/core/*": [
+          "src/modules/core/*",
+      ],
+    }
   }
 }

--- a/telemetry/packages/types/package.json
+++ b/telemetry/packages/types/package.json
@@ -1,11 +1,9 @@
 {
-  "name": "@hyped/telemetry-constants",
+  "name": "@hyped/telemetry-types",
   "private": true,
   "version": "0.0.0",
-  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@hyped/telemetry-types": "*",
     "typescript": "^4.9.4"
   },
   "scripts": {

--- a/telemetry/packages/types/src/index.ts
+++ b/telemetry/packages/types/src/index.ts
@@ -1,0 +1,6 @@
+
+export { POD_IDS } from './pods/pods.types';
+
+export type { Pods, Measurement, Pod } from './pods/pods.types';
+export type { OpenMctDictionary, OpenMctPod, OpenMctMeasurement } from './openmct/openmct-dictionary.types';
+export type { OpenMctObjectTypes, OpenMctObjectType } from './openmct/openmct-object-types.types';

--- a/telemetry/packages/types/src/index.ts
+++ b/telemetry/packages/types/src/index.ts
@@ -1,6 +1,4 @@
 
-export { POD_IDS } from './pods/pods.types';
-
 export type { Pods, Measurement, Pod } from './pods/pods.types';
 export type { OpenMctDictionary, OpenMctPod, OpenMctMeasurement } from './openmct/openmct-dictionary.types';
 export type { OpenMctObjectTypes, OpenMctObjectType } from './openmct/openmct-object-types.types';

--- a/telemetry/packages/types/src/openmct/openmct-dictionary.types.ts
+++ b/telemetry/packages/types/src/openmct/openmct-dictionary.types.ts
@@ -5,7 +5,7 @@ export type OpenMctMeasurement = {
   values: {
     key: string;
     name: string;
-    unit: string;
+    unit?: string;
     format: string;
     min?: number;
     max?: number;

--- a/telemetry/packages/types/src/openmct/openmct-dictionary.types.ts
+++ b/telemetry/packages/types/src/openmct/openmct-dictionary.types.ts
@@ -14,7 +14,8 @@ export type OpenMctMeasurement = {
       string: string;
     }[];
     hints?: {
-      range: number;
+      range?: number;
+      domain?: number;
     };
     source?: string;
     units?: {

--- a/telemetry/packages/types/src/openmct/openmct-dictionary.types.ts
+++ b/telemetry/packages/types/src/openmct/openmct-dictionary.types.ts
@@ -10,8 +10,8 @@ export type OpenMctMeasurement = {
     min?: number;
     max?: number;
     enumerations?: {
-      key: string;
-      value: string;
+      value: number;
+      string: string;
     }[];
     hints?: {
       range: number;

--- a/telemetry/packages/types/src/openmct/openmct-dictionary.types.ts
+++ b/telemetry/packages/types/src/openmct/openmct-dictionary.types.ts
@@ -25,7 +25,7 @@ export type OpenMctMeasurement = {
 
 export type OpenMctPod = {
   name: string;
-  podId: number;
+  id: number;
   measurements: OpenMctMeasurement[];
 };
 

--- a/telemetry/packages/types/src/openmct/openmct-dictionary.types.ts
+++ b/telemetry/packages/types/src/openmct/openmct-dictionary.types.ts
@@ -1,0 +1,32 @@
+export type OpenMctMeasurement = {
+  name: string;
+  key: string;
+  type: string;
+  values: {
+    key: string;
+    name: string;
+    unit: string;
+    format: string;
+    min?: number;
+    max?: number;
+    enumerations?: {
+      key: string;
+      value: string;
+    }[];
+    hints?: {
+      range: number;
+    };
+    source?: string;
+    units?: {
+      domain: string;
+    };
+  }[];
+};
+
+export type OpenMctPod = {
+  name: string;
+  podId: number;
+  measurements: OpenMctMeasurement[];
+};
+
+export type OpenMctDictionary = Record<string, OpenMctPod>;

--- a/telemetry/packages/types/src/openmct/openmct-object-types.types.ts
+++ b/telemetry/packages/types/src/openmct/openmct-object-types.types.ts
@@ -1,0 +1,7 @@
+export type OpenMctObjectType = {
+  id: string;
+  name: string;
+  icon: string;
+}
+
+export type OpenMctObjectTypes = OpenMctObjectType[];

--- a/telemetry/packages/types/src/pods/pods.types.ts
+++ b/telemetry/packages/types/src/pods/pods.types.ts
@@ -16,8 +16,8 @@ export type RangeMeasurement = BaseMeasurement & {
 export type EnumMeasurement = BaseMeasurement & {
   format: 'enum';
   enumerations: {
-    key: string;
-    value: string;
+    value: number;
+    string: string;
   }[];
 }
 

--- a/telemetry/packages/types/src/pods/pods.types.ts
+++ b/telemetry/packages/types/src/pods/pods.types.ts
@@ -1,3 +1,5 @@
+import { type } from "os";
+
 export const POD_IDS = ['1', '2'] as const;
 
 export type BaseMeasurement = {

--- a/telemetry/packages/types/src/pods/pods.types.ts
+++ b/telemetry/packages/types/src/pods/pods.types.ts
@@ -1,5 +1,3 @@
-export const POD_IDS = ['1', '2'] as const;
-
 export type BaseMeasurement = {
   name: string;
   key: string;
@@ -27,8 +25,8 @@ export type Measurement = RangeMeasurement | EnumMeasurement;
 
 export type Pod = {
   name: string;
-  podId: number;
+  id: number;
   measurements: Record<string, Measurement>;
 }
 
-export type Pods = Record<typeof POD_IDS[number], Pod>;
+export type Pods = Record<string, Pod>;

--- a/telemetry/packages/types/src/pods/pods.types.ts
+++ b/telemetry/packages/types/src/pods/pods.types.ts
@@ -1,5 +1,3 @@
-import { type } from "os";
-
 export const POD_IDS = ['1', '2'] as const;
 
 export type BaseMeasurement = {

--- a/telemetry/packages/types/tsconfig.json
+++ b/telemetry/packages/types/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "moduleResolution": "node",
+    "preserveWatchOutput": true,
+    "skipLibCheck": true,
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/telemetry/packages/ui/openmct/main.ts
+++ b/telemetry/packages/ui/openmct/main.ts
@@ -3,11 +3,10 @@ import openmct from 'openmct/dist/openmct';
 import { DictionaryPlugin } from './plugins/dictionary-plugin';
 import { HistoricalTelemetryPlugin } from './plugins/historical-telemetry-plugin';
 
-const timeWindow = 24 * 60 * 60 * 1000;
+const timeWindow = 15 * 60 * 1000;
 
 openmct.setAssetPath('/openmct-lib');
 
-// Bundled plugins
 openmct.install(openmct.plugins.LocalStorage());
 openmct.install(openmct.plugins.MyItems());
 openmct.install(openmct.plugins.UTCTimeSystem());

--- a/telemetry/packages/ui/openmct/main.ts
+++ b/telemetry/packages/ui/openmct/main.ts
@@ -1,8 +1,7 @@
 import openmct from 'openmct/dist/openmct';
-// import './plugins/lib/http';
+
 import { DictionaryPlugin } from './plugins/dictionary-plugin';
-// import { HistoricalTelemetryPlugin } from './plugins/historical-telemetry-plugin';
-// import { RealtimeTelemetryPlugin } from './plugins/realtime-telemetry-plugin';
+import { HistoricalTelemetryPlugin } from './plugins/historical-telemetry-plugin';
 
 const timeWindow = 24 * 60 * 60 * 1000;
 
@@ -12,6 +11,7 @@ openmct.setAssetPath('/openmct-lib');
 openmct.install(openmct.plugins.LocalStorage());
 openmct.install(openmct.plugins.MyItems());
 openmct.install(openmct.plugins.UTCTimeSystem());
+
 openmct.time.clock('local', { start: -timeWindow, end: 0 });
 openmct.time.timeSystem('utc');
 openmct.install(openmct.plugins['Espresso']());
@@ -31,26 +31,7 @@ openmct.install(
   }),
 );
 
-openmct.install(DictionaryPlugin())
-
-// Local plugins
-// var types = [];
-// var dictionaries = [];
-
-// for (var i = 0; i < dictionaries.length; i++) {
-//   openmct.install(
-//     DictionaryPlugin({
-//       name: dictionaries[i].name,
-//       description: dictionaries[i].options.description,
-//       key: dictionaries[i].key,
-//       type: dictionaries[i].key.telemetry,
-//       namespace: dictionaries[i].key.taxonomy,
-//     }),
-//   );
-//   types.push(dictionaries[i].key + '.telemetry');
-// }
-
-// openmct.install(HistoricalTelemetryPlugin(types));
-// openmct.install(RealtimeTelemetryPlugin(types));
+openmct.install(DictionaryPlugin());
+openmct.install(HistoricalTelemetryPlugin());
 
 openmct.start();

--- a/telemetry/packages/ui/openmct/plugins/data/object-types-data.ts
+++ b/telemetry/packages/ui/openmct/plugins/data/object-types-data.ts
@@ -1,0 +1,11 @@
+import { OpenMctObjectTypes } from "@hyped/telemetry-types";
+import { http } from "../../core/http";
+
+export function fetchObjectTypes() {
+  return http
+    .get('openmct/object-types')
+    .json<OpenMctObjectTypes>()
+    .then((data) => {
+      return data;
+    });
+}

--- a/telemetry/packages/ui/openmct/plugins/data/pods-data.ts
+++ b/telemetry/packages/ui/openmct/plugins/data/pods-data.ts
@@ -1,0 +1,20 @@
+import { OpenMctPod } from '@hyped/telemetry-types';
+import { http } from '../../core/http';
+
+export function fetchPodIds() {
+  return http
+    .get('openmct/dictionary/pods')
+    .json<{ ids: string[] }>()
+    .then((data) => {
+      return data;
+    });
+}
+
+export function fetchPod(id: string) {
+  return http
+    .get(`openmct/dictionary/pod/${id}`)
+    .json<OpenMctPod>()
+    .then((data) => {
+      return data;
+    });
+}

--- a/telemetry/packages/ui/openmct/plugins/data/pods-data.ts
+++ b/telemetry/packages/ui/openmct/plugins/data/pods-data.ts
@@ -12,7 +12,7 @@ export function fetchPodIds() {
 
 export function fetchPod(id: string) {
   return http
-    .get(`openmct/dictionary/pod/${id}`)
+    .get(`openmct/dictionary/pods/${id}`)
     .json<OpenMctPod>()
     .then((data) => {
       return data;

--- a/telemetry/packages/ui/openmct/plugins/dictionary-plugin.ts
+++ b/telemetry/packages/ui/openmct/plugins/dictionary-plugin.ts
@@ -2,7 +2,7 @@ import { OpenMCT } from 'openmct/dist/openmct';
 import { ObjectIdentitifer } from '../types/ObjectIdentifier';
 import { fetchPod, fetchPodIds } from './data/pods-data';
 import { fetchObjectTypes } from './data/object-types-data';
-import { getPodIdFromKey } from './utils/getPodIdFromKey';
+import { parsePodId } from './utils/parsePodId';
 
 const podObjectProvider = {
   get: (identifier: ObjectIdentitifer) => {
@@ -10,7 +10,7 @@ const podObjectProvider = {
       throw new Error('Invalid identifier');
     }
 
-    const podId = getPodIdFromKey(identifier.key);
+    const podId = parsePodId(identifier.key);
     return fetchPod(podId).then((pod) => {
       return {
         identifier,
@@ -22,13 +22,13 @@ const podObjectProvider = {
   },
 };
 
-const measurementObjectProvider = {
+const measurementsObjectProvider = {
   get: (identifier: ObjectIdentitifer) => {
     if (!identifier.namespace.startsWith('hyped.pod_')) {
       throw new Error('Invalid identifier');
     }
 
-    const podId = getPodIdFromKey(identifier.namespace);
+    const podId = parsePodId(identifier.namespace);
     return fetchPod(podId).then((pod) => {
       const measurement = pod.measurements.find(
         (measurement) => measurement.key === identifier.key,
@@ -59,7 +59,7 @@ const compositionProvider = {
     );
   },
   load: (domainObject: any) => {
-    const podId = getPodIdFromKey(domainObject.identifier.key);
+    const podId = parsePodId(domainObject.identifier.key);
     return fetchPod(podId).then((pod) =>
       pod.measurements.map((measurement: any) => {
         return {
@@ -85,7 +85,7 @@ export function DictionaryPlugin() {
           );
           openmct.objects.addProvider(
             `hyped.pod_${id}`,
-            measurementObjectProvider,
+            measurementsObjectProvider,
           );
         });
 

--- a/telemetry/packages/ui/openmct/plugins/dictionary-plugin.ts
+++ b/telemetry/packages/ui/openmct/plugins/dictionary-plugin.ts
@@ -1,85 +1,110 @@
-import { OpenMCT } from "openmct/dist/openmct"
-import { http } from "../core/http"
-import { ObjectIdentitifer } from "../types/ObjectIdentifier"
-import { ObjectType } from "../types/ObjectType"
+import { OpenMCT } from 'openmct/dist/openmct';
+import { ObjectIdentitifer } from '../types/ObjectIdentifier';
+import { fetchPod, fetchPodIds } from './data/pods-data';
+import { fetchObjectTypes } from './data/object-types-data';
+import { getPodIdFromKey } from './utils/getPodIdFromKey';
 
-function getDictionary() {
-  return http.get('openmct/dictionary').json().then((data) => {
-    return data
-  })
-}
-
-function getObjectTypes() {
-  return http.get('openmct/object-types').json<ObjectType[]>().then((data) => {
-    return data
-  })
-}
-
-const objectProvider = {
+const podObjectProvider = {
   get: (identifier: ObjectIdentitifer) => {
-    return getDictionary().then((dictionary: any) => {
-      if (identifier.key === 'pod_1') {
-        return {
-          identifier,
-          name: dictionary.name,
-          type: 'folder',
-          location: 'ROOT'
-        }
-      } else {
-        // TODOLater: Type :)
-        const measurement = dictionary.measurements.find((measurement: any) => measurement.key === identifier.key)
+    if (!identifier.key.startsWith('pod_')) {
+      throw new Error('Invalid identifier');
+    }
 
-        return {
-          identifier,
-          name: measurement.name,
-          // TODOLater: Maybe should check this exists
-          type: `hyped.${measurement.type}`,
-          telemetry: {
-            values: measurement.values
-          },
-          location: "hyped:pod_1"
-        }
+    const podId = getPodIdFromKey(identifier.key);
+    return fetchPod(podId).then((pod) => {
+      return {
+        identifier,
+        name: pod.name,
+        type: 'folder',
+        location: 'ROOT',
+      };
+    });
+  },
+};
+
+const measurementObjectProvider = {
+  get: (identifier: ObjectIdentitifer) => {
+    if (!identifier.namespace.startsWith('hyped.pod_')) {
+      throw new Error('Invalid identifier');
+    }
+
+    const podId = getPodIdFromKey(identifier.namespace);
+    return fetchPod(podId).then((pod) => {
+      const measurement = pod.measurements.find(
+        (measurement) => measurement.key === identifier.key,
+      );
+
+      if (!measurement) {
+        throw new Error('Measurement not found');
       }
-    })
-  }
-}
+
+      return {
+        identifier,
+        name: measurement.name,
+        type: `hyped.${measurement.type}`,
+        telemetry: {
+          values: measurement.values,
+        },
+        location: `hyped.taxonomy:pod_${podId}`,
+      };
+    });
+  },
+};
 
 const compositionProvider = {
   appliesTo: (domainObject: any) => {
-    return domainObject.identifier.namespace === 'hyped' && domainObject.type === 'folder'
+    return (
+      domainObject.identifier.namespace === 'hyped.taxonomy' &&
+      domainObject.type === 'folder'
+    );
   },
   load: (domainObject: any) => {
-    return getDictionary().then((dictionary: any) => {
-      return dictionary.measurements.map((measurement: any) => {
+    const podId = getPodIdFromKey(domainObject.identifier.key);
+    return fetchPod(podId).then((pod) =>
+      pod.measurements.map((measurement: any) => {
         return {
-          namespace: 'hyped',
-          key: measurement.key
-        }
-      })
-    })
-  }
-}
+          namespace: `hyped.pod_${podId}`,
+          key: measurement.key,
+        };
+      }),
+    );
+  },
+};
 
 export function DictionaryPlugin() {
   return function install(openmct: OpenMCT) {
-    openmct.objects.addRoot({
-      namespace: 'hyped',
-      key: 'pod_1'
-    }, openmct.priority.HIGH)
+    fetchPodIds()
+      .then(({ ids }) => {
+        ids.forEach((id) => {
+          openmct.objects.addRoot(
+            {
+              namespace: `hyped.taxonomy`,
+              key: `pod_${id}`,
+            },
+            openmct.priority.HIGH,
+          );
+          openmct.objects.addProvider(
+            `hyped.pod_${id}`,
+            measurementObjectProvider,
+          );
+        });
 
-    openmct.objects.addProvider('hyped', objectProvider)
+        openmct.objects.addProvider(`hyped.taxonomy`, podObjectProvider);
+      })
+      .catch((err) => {
+        console.error(err);
+        throw new Error('Failed to load dictionary');
+      });
 
-    getObjectTypes().then((objectTypes) => {
-      objectTypes.map((objectType) => {
+    fetchObjectTypes().then((objectTypes) => {
+      objectTypes.forEach((objectType) => {
         openmct.types.addType(`hyped.${objectType.id}`, {
           name: objectType.name,
-          // description: objectType.name,
           cssClass: objectType.icon,
-        })
-      })
-    })
+        });
+      });
+    });
 
-    openmct.composition.addProvider(compositionProvider as any)
-  }
+    openmct.composition.addProvider(compositionProvider as any);
+  };
 }
-

--- a/telemetry/packages/ui/openmct/plugins/historical-telemetry-plugin.ts
+++ b/telemetry/packages/ui/openmct/plugins/historical-telemetry-plugin.ts
@@ -1,0 +1,23 @@
+import { OpenMCT } from 'openmct/dist/openmct';
+import { http } from '../core/http';
+import { getPodIdFromKey } from './utils/getPodIdFromKey';
+
+export function HistoricalTelemetryPlugin() {
+  return function install(openmct: OpenMCT) {
+    const provider = {
+      supportsRequest: function (domainObject: any) {
+        return domainObject.type.startsWith('hyped.');
+      },
+      request: function (domainObject: any, options: any) {
+        const url = `openmct/data/historical/pods/${getPodIdFromKey(domainObject.identifier.namespace)}/measurements/${domainObject.identifier.key}?start=${options.start}&end=${options.end}`
+
+        return http
+          .get(url)
+          .json()
+          .then((data) => data);
+      },
+    };
+
+    openmct.telemetry.addProvider(provider);
+  };
+}

--- a/telemetry/packages/ui/openmct/plugins/historical-telemetry-plugin.ts
+++ b/telemetry/packages/ui/openmct/plugins/historical-telemetry-plugin.ts
@@ -1,15 +1,20 @@
 import { OpenMCT } from 'openmct/dist/openmct';
 import { http } from '../core/http';
-import { getPodIdFromKey } from './utils/getPodIdFromKey';
+import { parsePodId } from './utils/parsePodId';
+import { DomainObject } from 'openmct/dist/src/api/objects/ObjectAPI';
+import { TelemetryRequest } from 'openmct/dist/src/api/telemetry/TelemetryAPI';
 
 export function HistoricalTelemetryPlugin() {
   return function install(openmct: OpenMCT) {
     const provider = {
-      supportsRequest: function (domainObject: any) {
+      supportsRequest: function (domainObject: DomainObject) {
         return domainObject.type.startsWith('hyped.');
       },
-      request: function (domainObject: any, options: any) {
-        const url = `openmct/data/historical/pods/${getPodIdFromKey(domainObject.identifier.namespace)}/measurements/${domainObject.identifier.key}?start=${options.start}&end=${options.end}`
+      request: function (domainObject: DomainObject, options: TelemetryRequest) {
+        const { start, end } = options;
+        const podId = parsePodId(domainObject.identifier.namespace)
+        const measurementKey = domainObject.identifier.key;
+        const url = `openmct/data/historical/pods/${podId}/measurements/${measurementKey}?start=${start}&end=${end}`
 
         return http
           .get(url)

--- a/telemetry/packages/ui/openmct/plugins/utils/getPodIdFromKey.ts
+++ b/telemetry/packages/ui/openmct/plugins/utils/getPodIdFromKey.ts
@@ -1,0 +1,4 @@
+export function getPodIdFromKey(key: string): string {
+  const podId = key.split('_')[1]
+  return podId
+}

--- a/telemetry/packages/ui/openmct/plugins/utils/getPodIdFromKey.ts
+++ b/telemetry/packages/ui/openmct/plugins/utils/getPodIdFromKey.ts
@@ -1,4 +1,0 @@
-export function getPodIdFromKey(key: string): string {
-  const podId = key.split('_')[1]
-  return podId
-}

--- a/telemetry/packages/ui/openmct/plugins/utils/parsePodId.ts
+++ b/telemetry/packages/ui/openmct/plugins/utils/parsePodId.ts
@@ -1,0 +1,4 @@
+export function parsePodId(key: string): string {
+  const podId = key.split('_')[1]
+  return podId
+}

--- a/telemetry/packages/ui/openmct/types/ObjectType.ts
+++ b/telemetry/packages/ui/openmct/types/ObjectType.ts
@@ -1,5 +1,0 @@
-export type ObjectType = {
-  id: string;
-  name: string;
-  icon: string;
-}

--- a/telemetry/packages/ui/package.json
+++ b/telemetry/packages/ui/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@hyped/telemetry-types": "*",
     "@fontsource/raleway": "^4.5.12",
     "@headlessui/react": "^1.7.10",
     "@types/node": "^18.11.18",


### PR DESCRIPTION
- Add `MqttIngestion` and `MeasurementService` to read data from MQTT and write it to Influx (database)
- Add `HistoricalService` and `historical-data-plugin` to query data from Influx and return it back to OpenMCT

![image](https://github.com/Hyp-ed/hyped-2023/assets/7504589/06406405-e23d-46b0-91c0-ff862aa913da)
