### PR TITLE
feat(tel): ROS to MQTT

### DIFF
--- a/src/ros/ros_to_mqtt/config.yaml
+++ b/src/ros/ros_to_mqtt/config.yaml
@@ -17,9 +17,9 @@ ros-to-mqtt:
 mqtt-to-ros:
   - mqtt_topic_name: "mqtt1"
     message_type: "string"
-    function: "callback3"
+    function: "string_callback"
     ros_topic_name: "mqtt1"
   - mqtt_topic_name: "mqtt2"
     message_type: "float"
-    function: "callback4"
+    function: "float_callback"
     ros_topic_name: "mqtt2"

--- a/src/ros/ros_to_mqtt/config.yaml
+++ b/src/ros/ros_to_mqtt/config.yaml
@@ -1,0 +1,14 @@
+mqtt:
+  connection:
+    host: localhost
+    port: 1883
+    keepalive: 60
+topics:
+  - topic_name: "topic1"
+    message_type: "std_msgs/String"
+    function: "callback1"
+    mqtt_topic: "topic1"
+  - topic_name: "topic2"
+    message_type: "std_msgs/String"
+    function: "callback2"
+    mqtt_topic: "topic2"

--- a/src/ros/ros_to_mqtt/config.yaml
+++ b/src/ros/ros_to_mqtt/config.yaml
@@ -4,21 +4,22 @@ mqtt:
     host: localhost
     port: 1883
     keepalive: 60
+  qos: 0
 ros-to-mqtt:
   - ros_topic_name: "ros1"
-    message_type: "std_msgs/String"
-    function: "callback1"
+    message_type: "string"
+    function: "string_callback"
     mqtt_topic_name: "ros1"
   - ros_topic_name: "ros2"
-    message_type: "std_msgs/String"
-    function: "callback2"
+    message_type: "float"
+    function: "float_callback"
     mqtt_topic_name: "ros2"
 mqtt-to-ros:
   - mqtt_topic_name: "mqtt1"
-    message_type: "std_msgs/String"
+    message_type: "string"
     function: "callback3"
     ros_topic_name: "mqtt1"
   - mqtt_topic_name: "mqtt2"
-    message_type: "std_msgs/String"
+    message_type: "float"
     function: "callback4"
     ros_topic_name: "mqtt2"

--- a/src/ros/ros_to_mqtt/config.yaml
+++ b/src/ros/ros_to_mqtt/config.yaml
@@ -1,14 +1,24 @@
+# WARNING: could cause infinite loop if you have same topic names going both ways?
 mqtt:
   connection:
     host: localhost
     port: 1883
     keepalive: 60
-topics:
-  - topic_name: "topic1"
+ros-to-mqtt:
+  - ros_topic_name: "ros1"
     message_type: "std_msgs/String"
     function: "callback1"
-    mqtt_topic: "topic1"
-  - topic_name: "topic2"
+    mqtt_topic_name: "ros1"
+  - ros_topic_name: "ros2"
     message_type: "std_msgs/String"
     function: "callback2"
-    mqtt_topic: "topic2"
+    mqtt_topic_name: "ros2"
+mqtt-to-ros:
+  - mqtt_topic_name: "mqtt1"
+    message_type: "std_msgs/String"
+    function: "callback3"
+    ros_topic_name: "mqtt1"
+  - mqtt_topic_name: "mqtt2"
+    message_type: "std_msgs/String"
+    function: "callback4"
+    ros_topic_name: "mqtt2"

--- a/src/ros/ros_to_mqtt/package.xml
+++ b/src/ros/ros_to_mqtt/package.xml
@@ -14,6 +14,7 @@
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>paho-mqtt</exec_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/src/ros/ros_to_mqtt/package.xml
+++ b/src/ros/ros_to_mqtt/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ros_to_mqtt</name>
+  <version>0.0.0</version>
+  <description>Converts ROS messages to MQTT for telemetry system.</description>
+  <maintainer email="s2206112@ed.ac.uk">David Beechey</maintainer>
+  <license>TODO: License declaration</license>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/src/ros/ros_to_mqtt/ros_to_mqtt/mqtt_listener.py
+++ b/src/ros/ros_to_mqtt/ros_to_mqtt/mqtt_listener.py
@@ -1,9 +1,9 @@
 import paho.mqtt.client as mqtt
-
-# The callback for when the client receives a CONNACK response from the server.
+import yaml
 
 
 def on_connect(client, userdata, flags, rc):
+    """ The callback for when the client receives a CONNACK response from the server. """
     print("Connected with result code "+str(rc))
 
     # Subscribing in on_connect() means that if we lose the connection and
@@ -12,18 +12,23 @@ def on_connect(client, userdata, flags, rc):
     # subscribe to all topics
     client.subscribe("#")
 
-# The callback for when a PUBLISH message is received from the server.
-
 
 def on_message(client, userdata, msg):
-    print(f"MQTT LISTEN: {msg.topic} {str(msg.payload)}")
+    """ The callback for when a PUBLISH message is received from the server."""
+    print(f"MQTT Listener: {msg.topic} {str(msg.payload)}")
 
 
+# Create an MQTT client
 client = mqtt.Client()
+
 client.on_connect = on_connect
 client.on_message = on_message
 
-client.connect("localhost", 1883, 60)
+# Connect to the MQTT broker
+with open("config.yaml", "r") as config_file:
+    config = yaml.safe_load(config_file)
+    client.connect(config["mqtt"]["connection"]["host"],
+                   config["mqtt"]["connection"]["port"], config["mqtt"]["connection"]["keepalive"])
 
 # Blocking call that processes network traffic, dispatches callbacks and
 # handles reconnecting.

--- a/src/ros/ros_to_mqtt/ros_to_mqtt/mqtt_listener.py
+++ b/src/ros/ros_to_mqtt/ros_to_mqtt/mqtt_listener.py
@@ -1,0 +1,32 @@
+import paho.mqtt.client as mqtt
+
+# The callback for when the client receives a CONNACK response from the server.
+
+
+def on_connect(client, userdata, flags, rc):
+    print("Connected with result code "+str(rc))
+
+    # Subscribing in on_connect() means that if we lose the connection and
+    # reconnect then subscriptions will be renewed.
+
+    # subscribe to all topics
+    client.subscribe("#")
+
+# The callback for when a PUBLISH message is received from the server.
+
+
+def on_message(client, userdata, msg):
+    print(f"MQTT LISTEN: {msg.topic} {str(msg.payload)}")
+
+
+client = mqtt.Client()
+client.on_connect = on_connect
+client.on_message = on_message
+
+client.connect("localhost", 1883, 60)
+
+# Blocking call that processes network traffic, dispatches callbacks and
+# handles reconnecting.
+# Other loop*() functions are available that give a threaded interface and a
+# manual interface.
+client.loop_forever()

--- a/src/ros/ros_to_mqtt/ros_to_mqtt/mqtt_listener.py
+++ b/src/ros/ros_to_mqtt/ros_to_mqtt/mqtt_listener.py
@@ -9,13 +9,14 @@ def on_connect(client, userdata, flags, rc):
     # Subscribing in on_connect() means that if we lose the connection and
     # reconnect then subscriptions will be renewed.
 
-    # subscribe to all topics
     client.subscribe("#")
+    print("Subscribed to all topics")
 
 
 def on_message(client, userdata, msg):
     """ The callback for when a PUBLISH message is received from the server."""
-    print(f"MQTT Listener: {msg.topic} {str(msg.payload)}")
+    print(
+        f"MQTT Listener: Receieved message: {str(msg.payload)} on topic {msg.topic}")
 
 
 # Create an MQTT client
@@ -24,11 +25,12 @@ client = mqtt.Client()
 client.on_connect = on_connect
 client.on_message = on_message
 
-# Connect to the MQTT broker
 with open("config.yaml", "r") as config_file:
     config = yaml.safe_load(config_file)
-    client.connect(config["mqtt"]["connection"]["host"],
-                   config["mqtt"]["connection"]["port"], config["mqtt"]["connection"]["keepalive"])
+
+# Connect to the MQTT broker using the configuration
+client.connect(config["mqtt"]["connection"]["host"],
+               config["mqtt"]["connection"]["port"], config["mqtt"]["connection"]["keepalive"])
 
 # Blocking call that processes network traffic, dispatches callbacks and
 # handles reconnecting.

--- a/src/ros/ros_to_mqtt/ros_to_mqtt/mqtt_test_publisher.py
+++ b/src/ros/ros_to_mqtt/ros_to_mqtt/mqtt_test_publisher.py
@@ -1,0 +1,19 @@
+import paho.mqtt.client as mqtt
+import time
+
+# Create an MQTT client
+client = mqtt.Client()
+
+# Connect to the MQTT broker
+client.connect('localhost', 1883, 60)
+
+i = 0
+
+# Publish messages to the topic indefinitely
+while True:
+    client.publish("mqtt1", "Hello from MQTT mqtt1!" + str(i))
+    print("MQTT PUBLISH: Hello from MQTT mqtt1!" + str(i))
+    client.publish("mqtt2", "Hello from MQTT mqtt2!" + str(i))
+    print("MQTT PUBLISH: Hello from MQTT mqtt2!" + str(i))
+    time.sleep(1)  # Adjust the sleep duration as needed
+    i += 1

--- a/src/ros/ros_to_mqtt/ros_to_mqtt/mqtt_test_publisher.py
+++ b/src/ros/ros_to_mqtt/ros_to_mqtt/mqtt_test_publisher.py
@@ -1,19 +1,26 @@
 import paho.mqtt.client as mqtt
 import time
+import yaml
 
 # Create an MQTT client
 client = mqtt.Client()
 
 # Connect to the MQTT broker
-client.connect('localhost', 1883, 60)
+with open("config.yaml", "r") as config_file:
+    config = yaml.safe_load(config_file)
+    client.connect(config["mqtt"]["connection"]["host"],
+                   config["mqtt"]["connection"]["port"], config["mqtt"]["connection"]["keepalive"])
 
+mqtt_qos = config["mqtt"]["qos"]
 i = 0
 
 # Publish messages to the topic indefinitely
 while True:
-    client.publish("mqtt1", "Hello from MQTT mqtt1!" + str(i))
-    print("MQTT PUBLISH: Hello from MQTT mqtt1!" + str(i))
-    client.publish("mqtt2", "Hello from MQTT mqtt2!" + str(i))
-    print("MQTT PUBLISH: Hello from MQTT mqtt2!" + str(i))
-    time.sleep(1)  # Adjust the sleep duration as needed
+    client.publish("mqtt1", "Hello from MQTT mqtt1! No." + str(i), mqtt_qos)
+    print("MQTT PUBLISH: Hello from MQTT mqtt1! No." + str(i))
+
+    client.publish("mqtt2", "Hello from MQTT mqtt2! No." + str(i), mqtt_qos)
+    print("MQTT PUBLISH: Hello from MQTT mqtt2! No." + str(i))
+
+    time.sleep(1)
     i += 1

--- a/src/ros/ros_to_mqtt/ros_to_mqtt/mqtt_test_publisher.py
+++ b/src/ros/ros_to_mqtt/ros_to_mqtt/mqtt_test_publisher.py
@@ -5,22 +5,23 @@ import yaml
 # Create an MQTT client
 client = mqtt.Client()
 
-# Connect to the MQTT broker
 with open("config.yaml", "r") as config_file:
     config = yaml.safe_load(config_file)
-    client.connect(config["mqtt"]["connection"]["host"],
-                   config["mqtt"]["connection"]["port"], config["mqtt"]["connection"]["keepalive"])
 
 mqtt_qos = config["mqtt"]["qos"]
-i = 0
+
+# Connect to the MQTT broker
+client.connect(config["mqtt"]["connection"]["host"],
+               config["mqtt"]["connection"]["port"], config["mqtt"]["connection"]["keepalive"])
 
 # Publish messages to the topic indefinitely
+i = 0
 while True:
     client.publish("mqtt1", "Hello from MQTT mqtt1! No." + str(i), mqtt_qos)
     print("MQTT PUBLISH: Hello from MQTT mqtt1! No." + str(i))
 
-    client.publish("mqtt2", "Hello from MQTT mqtt2! No." + str(i), mqtt_qos)
-    print("MQTT PUBLISH: Hello from MQTT mqtt2! No." + str(i))
+    client.publish("mqtt2", float(i), mqtt_qos)
+    print("MQTT PUBLISH: " + str(i))
 
     time.sleep(1)
     i += 1

--- a/src/ros/ros_to_mqtt/ros_to_mqtt/ros_listener.py
+++ b/src/ros/ros_to_mqtt/ros_to_mqtt/ros_listener.py
@@ -3,9 +3,9 @@ from rclpy.node import Node
 from std_msgs.msg import String
 
 
-class SimpleListener(Node):
+class ROSListener(Node):
     def __init__(self):
-        super().__init__('simple_listener')
+        super().__init__('ros_listener')
 
         # Subscribe to the desired topic
         self.subscription1 = self.create_subscription(
@@ -26,13 +26,13 @@ class SimpleListener(Node):
 
     def callback(self, msg):
         # Callback function to process received messages
-        self.get_logger().info(f'ROS LISTENER: Received message: {msg.data}')
+        self.get_logger().info(f'ROS Listener: Received message: {msg.data}')
 
 
 def main(args=None):
     rclpy.init(args=args)
 
-    simple_listener = SimpleListener()
+    simple_listener = ROSListener()
     rclpy.spin(simple_listener)
 
     simple_listener.destroy_node()

--- a/src/ros/ros_to_mqtt/ros_to_mqtt/ros_listener.py
+++ b/src/ros/ros_to_mqtt/ros_to_mqtt/ros_listener.py
@@ -1,28 +1,25 @@
 import rclpy
 from rclpy.node import Node
-from std_msgs.msg import String
+from std_msgs.msg import String, Float32
 
 
 class ROSListener(Node):
     def __init__(self):
         super().__init__('ros_listener')
 
-        # Subscribe to the desired topic
-        self.subscription1 = self.create_subscription(
-            String,  # Replace with the appropriate message type
-            'mqtt1',  # Replace with the desired topic name
+        self.subscription_1 = self.create_subscription(
+            String,
+            'mqtt1',
             self.callback,
             10
         )
-        self.subscription1
 
-        self.subscription2 = self.create_subscription(
-            String,  # Replace with the appropriate message type
-            'mqtt2',  # Replace with the desired topic name
+        self.subscription_2 = self.create_subscription(
+            Float32,
+            'mqtt2',
             self.callback,
             10
         )
-        self.subscription2
 
     def callback(self, msg):
         # Callback function to process received messages

--- a/src/ros/ros_to_mqtt/ros_to_mqtt/ros_listener.py
+++ b/src/ros/ros_to_mqtt/ros_to_mqtt/ros_listener.py
@@ -1,0 +1,43 @@
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import String
+
+
+class SimpleListener(Node):
+    def __init__(self):
+        super().__init__('simple_listener')
+
+        # Subscribe to the desired topic
+        self.subscription1 = self.create_subscription(
+            String,  # Replace with the appropriate message type
+            'mqtt1',  # Replace with the desired topic name
+            self.callback,
+            10
+        )
+        self.subscription1
+
+        self.subscription2 = self.create_subscription(
+            String,  # Replace with the appropriate message type
+            'mqtt2',  # Replace with the desired topic name
+            self.callback,
+            10
+        )
+        self.subscription2
+
+    def callback(self, msg):
+        # Callback function to process received messages
+        self.get_logger().info(f'ROS LISTENER: Received message: {msg.data}')
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    simple_listener = SimpleListener()
+    rclpy.spin(simple_listener)
+
+    simple_listener.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/ros/ros_to_mqtt/ros_to_mqtt/ros_test_publisher.py
+++ b/src/ros/ros_to_mqtt/ros_to_mqtt/ros_test_publisher.py
@@ -19,7 +19,6 @@ from std_msgs.msg import String, Float32
 
 
 class ROSTestPublisher(Node):
-
     def __init__(self):
         super().__init__('ros_test_publisher')
         self.publisher1_ = self.create_publisher(String, 'ros1', 10)
@@ -46,7 +45,6 @@ def main(args=None):
     rclpy.init(args=args)
 
     minimal_publisher = ROSTestPublisher()
-
     rclpy.spin(minimal_publisher)
 
     # Destroy the node explicitly

--- a/src/ros/ros_to_mqtt/ros_to_mqtt/ros_test_publisher.py
+++ b/src/ros/ros_to_mqtt/ros_to_mqtt/ros_test_publisher.py
@@ -22,22 +22,22 @@ class MinimalPublisher(Node):
 
     def __init__(self):
         super().__init__('minimal_publisher')
-        self.publisher1_ = self.create_publisher(String, 'topic1', 10)
-        self.publisher2_ = self.create_publisher(String, 'topic2', 10)
+        self.publisher1_ = self.create_publisher(String, 'ros1', 10)
+        self.publisher2_ = self.create_publisher(String, 'ros2', 10)
         timer_period = 1  # seconds
         self.timer = self.create_timer(timer_period, self.timer_callback)
         self.i = 0
 
     def timer_callback(self):
         msg1 = String()
-        msg1.data = 'Topic 1: %d' % self.i
+        msg1.data = 'ros1: %d' % self.i
         self.publisher1_.publish(msg1)
-        self.get_logger().info('Publishing: "%s"' % msg1.data)
+        self.get_logger().info('ROS Publishing: "%s"' % msg1.data)
 
         msg2 = String()
-        msg2.data = 'Topic 2: %d' % self.i
+        msg2.data = 'ro2: %d' % self.i
         self.publisher2_.publish(msg2)
-        self.get_logger().info('Publishing: "%s"' % msg2.data)
+        self.get_logger().info('ROS Publishing: "%s"' % msg2.data)
 
         self.i += 1
 

--- a/src/ros/ros_to_mqtt/ros_to_mqtt/ros_test_publisher.py
+++ b/src/ros/ros_to_mqtt/ros_to_mqtt/ros_test_publisher.py
@@ -15,15 +15,15 @@
 import rclpy
 from rclpy.node import Node
 
-from std_msgs.msg import String
+from std_msgs.msg import String, Float32
 
 
-class MinimalPublisher(Node):
+class ROSTestPublisher(Node):
 
     def __init__(self):
-        super().__init__('minimal_publisher')
+        super().__init__('ros_test_publisher')
         self.publisher1_ = self.create_publisher(String, 'ros1', 10)
-        self.publisher2_ = self.create_publisher(String, 'ros2', 10)
+        self.publisher2_ = self.create_publisher(Float32, 'ros2', 10)
         timer_period = 1  # seconds
         self.timer = self.create_timer(timer_period, self.timer_callback)
         self.i = 0
@@ -32,12 +32,12 @@ class MinimalPublisher(Node):
         msg1 = String()
         msg1.data = 'ros1: %d' % self.i
         self.publisher1_.publish(msg1)
-        self.get_logger().info('ROS Publishing: "%s"' % msg1.data)
+        self.get_logger().info(f'ROS Publishing: {msg1.data}')
 
-        msg2 = String()
-        msg2.data = 'ro2: %d' % self.i
+        msg2 = Float32()
+        msg2.data = float(self.i)
         self.publisher2_.publish(msg2)
-        self.get_logger().info('ROS Publishing: "%s"' % msg2.data)
+        self.get_logger().info(f'ROS Publishing: {str(msg2.data)}')
 
         self.i += 1
 
@@ -45,7 +45,7 @@ class MinimalPublisher(Node):
 def main(args=None):
     rclpy.init(args=args)
 
-    minimal_publisher = MinimalPublisher()
+    minimal_publisher = ROSTestPublisher()
 
     rclpy.spin(minimal_publisher)
 

--- a/src/ros/ros_to_mqtt/ros_to_mqtt/ros_to_mqtt.py
+++ b/src/ros/ros_to_mqtt/ros_to_mqtt/ros_to_mqtt.py
@@ -17,16 +17,16 @@ class RosToMqttBridge(Node):
         self.mqtt_keepalive = mqtt_config['keepalive']
 
         # ROS topics configuration
-        topics_config = config['topics']
+        ros_to_mqtt_topic_config = config['ros-to-mqtt']
 
         # Connect to the MQTT broker
         self.connect_mqtt()
 
         # Subscribe to ROS topics and publish to MQTT
-        for topic_config in topics_config:
-            topic_name = topic_config['topic_name']
+        for topic_config in ros_to_mqtt_topic_config:
+            topic_name = topic_config['ros_topic_name']
             message_type = topic_config['message_type']
-            mqtt_topic = topic_config['mqtt_topic']
+            mqtt_topic = topic_config['mqtt_topic_name']
             callback_function = getattr(
                 self, topic_config['function'])
 
@@ -54,16 +54,93 @@ class RosToMqttBridge(Node):
 
     def callback1(self, msg, topic_name):
         # Callback function for topic1
-        self.get_logger().info(f'Received message on topic1: {msg.data}')
+        self.get_logger().info(
+            f'Received message on {topic_name} (callback1): {msg.data}')
         # Do some processing on msg here
         msg.data = msg.data + ' processed'
         return msg
 
     def callback2(self, msg, topic_name):
         # Callback function for topic2
-        self.get_logger().info(f'Received message on topic2: {msg.data}')
+        self.get_logger().info(
+            f'Received message on {topic_name} (callback2): {msg.data}')
         # Do some processing on msg here
         return msg
+
+
+class MqttToRosBridge(Node):
+    def __init__(self, config):
+        super().__init__('mqtt_to_ros_bridge')
+        self.mqtt_client = None
+
+        # MQTT connection configuration
+        mqtt_config = config['mqtt']['connection']
+        self.mqtt_host = mqtt_config['host']
+        self.mqtt_port = mqtt_config['port']
+        self.mqtt_keepalive = mqtt_config['keepalive']
+
+        # ROS topics configuration
+        mqtt_to_ros_topic_config = config['mqtt-to-ros']
+
+        # Connect to the MQTT broker
+        self.connect_mqtt()
+
+        # def on_message(client, userdata, message):
+        #     print(f"message received {message.payload.decode('utf-8')}")
+
+        # self.mqtt_client.on_message = on_message
+
+        # self.mqtt_client.on_message = self.create_callback(mqtt_to_ros_topic_config["function"])
+
+        for topic_config in mqtt_to_ros_topic_config:
+            topic_name = topic_config['mqtt_topic_name']
+            message_type = topic_config['message_type']
+            mqtt_topic = topic_config['ros_topic_name']
+            callback_function = getattr(
+                self, topic_config['function'])
+
+            self.mqtt_client.message_callback_add(
+                topic_name, self.create_callback(callback_function, mqtt_topic))
+
+        # Subscribe to MQTT topics by passing an array of topic names
+        self.mqtt_client.subscribe(
+            [(topic_config['mqtt_topic_name'], 0) for topic_config in mqtt_to_ros_topic_config])
+
+    def connect_mqtt(self):
+        # Connect to the MQTT broker
+        self.mqtt_client = mqtt.Client()
+        self.mqtt_client.connect(
+            self.mqtt_host, self.mqtt_port, self.mqtt_keepalive)
+        self.mqtt_client.loop_start()
+
+    def create_callback(self, callback_function, topic_name):
+        def callback_wrapper(client, userdata, message):
+            # This wrapper function allows passing the topic name to the callback
+            msg = callback_function(message, topic_name)
+            # Publish to ROS
+            msg1 = String()
+            msg1.data = msg
+            self.create_publisher(
+                String, topic_name, 10).publish(msg1)
+
+        return callback_wrapper
+
+    def callback3(self, msg, topic_name):
+        # Callback function for topic1
+        # self.get_logger().info(
+        #     f'Received message on {topic_name} (callback3): {msg.data}')
+        # Do some processing on msg here
+        # msg.data = msg.data + ' processed'
+        print(msg.payload.decode('utf-8'))
+        return msg.payload.decode('utf-8')
+
+    def callback4(self, msg, topic_name):
+        # Callback function for topic2
+        # self.get_logger().info(
+        #     f'Received message on {topic_name} (callback4): {msg.data}')
+        # Do some processing on msg here
+        print(msg.payload.decode('utf-8'))
+        return msg.payload.decode('utf-8')
 
 
 def main(args=None):
@@ -75,7 +152,9 @@ def main(args=None):
         config = yaml.safe_load(file)
 
     ros_to_mqtt_bridge = RosToMqttBridge(config)
+    mqtt_to_ros_bridge = MqttToRosBridge(config)
     rclpy.spin(ros_to_mqtt_bridge)
+    rclpy.spin(mqtt_to_ros_bridge)
     rclpy.shutdown()
 
 

--- a/src/ros/ros_to_mqtt/ros_to_mqtt/ros_to_mqtt.py
+++ b/src/ros/ros_to_mqtt/ros_to_mqtt/ros_to_mqtt.py
@@ -1,6 +1,7 @@
 import rclpy
 from rclpy.node import Node
 from rcl_interfaces.msg import Log
+import paho.mqtt.client as mqtt
 
 
 class RosoutSubscriber(Node):
@@ -14,15 +15,24 @@ class RosoutSubscriber(Node):
             10
         )
 
+        self.client = mqtt.Client()
+        self.client.on_connect = self.on_connect
+        self.client.connect("localhost", 1883, 60)
+
     def rosout_callback(self, msg):
         # Process the received rosout message here
         # We don't want to log the rosout_subscriber's own messages (or we'll get an infinite loop)
         if (msg.name == "rosout_subscriber"):
             return
         self.log(msg)
+        self.client.publish(
+            "from_rosout", f"{msg.level}: {msg.name}: {msg.msg}")
 
     def log(self, msg):
-        self.get_logger().info(f"ROSOUT: {msg.level}: {msg.name}: {msg.msg}")
+        self.get_logger().info(f"ROSOUT: {msg}")
+
+    def on_connect(client, userdata, flags, rc):
+        print("Connected with result code "+str(rc))
 
 
 def main(args=None):

--- a/src/ros/ros_to_mqtt/ros_to_mqtt/ros_to_mqtt.py
+++ b/src/ros/ros_to_mqtt/ros_to_mqtt/ros_to_mqtt.py
@@ -1,6 +1,6 @@
 import rclpy
 from rclpy.node import Node
-from std_msgs.msg import String
+from std_msgs.msg import String, Float32
 import paho.mqtt.client as mqtt
 
 
@@ -16,6 +16,8 @@ class RosToMqttBridge(Node):
         self.mqtt_port = mqtt_config['port']
         self.mqtt_keepalive = mqtt_config['keepalive']
 
+        self.mqtt_qos = config["mqtt"]["qos"]
+
         # ROS topics configuration
         ros_to_mqtt_topic_config = config['ros-to-mqtt']
 
@@ -24,46 +26,50 @@ class RosToMqttBridge(Node):
 
         # Subscribe to ROS topics and publish to MQTT
         for topic_config in ros_to_mqtt_topic_config:
-            topic_name = topic_config['ros_topic_name']
+            ros_topic_name = topic_config['ros_topic_name']
             message_type = topic_config['message_type']
-            mqtt_topic = topic_config['mqtt_topic_name']
+            mqtt_topic_name = topic_config['mqtt_topic_name']
             callback_function = getattr(
                 self, topic_config['function'])
 
             self.subscription_list.append(self.create_subscription(
-                msg_type=String,  # Replace with the appropriate message type
-                topic=topic_name,
-                callback=self.create_callback(callback_function, mqtt_topic),
+                msg_type=Float32 if message_type == "float" else String,
+                topic=ros_topic_name,
+                callback=self.create_callback(
+                    callback_function, mqtt_topic_name),
                 qos_profile=rclpy.qos.qos_profile_sensor_data
+                # TODO: I think we can use callback_args here to pass the mqtt_topic_name without using a wrapper function
             ))
 
     def connect_mqtt(self):
-        # Connect to the MQTT broker
+        """ Connects to the MQTT broker """
         self.mqtt_client = mqtt.Client()
         self.mqtt_client.connect(
             self.mqtt_host, self.mqtt_port, self.mqtt_keepalive)
         self.mqtt_client.loop_start()
 
     def create_callback(self, callback_function, topic_name):
+        """ Create a callback function for the subscription """
         def callback_wrapper(msg):
-            # This wrapper function allows passing the topic name to the callback
+            """ This wrapper function allows passing the topic name to the callback and sharing code between the callbacks """
             msg = callback_function(msg, topic_name)
-            self.mqtt_client.publish(topic_name, msg.data)
+            # Publish to MQTT
+            self.mqtt_client.publish(topic_name, msg.data, self.mqtt_qos)
 
         return callback_wrapper
 
-    def callback1(self, msg, topic_name):
-        # Callback function for topic1
+    def string_callback(self, msg, topic_name):
+        """ Callback function for topic1 """
         self.get_logger().info(
-            f'Received message on {topic_name} (callback1): {msg.data}')
+            f'Received ROS message on {topic_name} (string_callback): {msg.data}')
         # Do some processing on msg here
-        msg.data = msg.data + ' processed'
+        msg.data = msg.data + ' processed by callback1'
         return msg
 
-    def callback2(self, msg, topic_name):
-        # Callback function for topic2
+    def float_callback(self, msg, topic_name):
+        """ Callback function for topic2 """
         self.get_logger().info(
-            f'Received message on {topic_name} (callback2): {msg.data}')
+            f'Received ROS message on {topic_name} (float_callback): {str(msg.data)}')
         # Do some processing on msg here
         return msg
 
@@ -85,13 +91,7 @@ class MqttToRosBridge(Node):
         # Connect to the MQTT broker
         self.connect_mqtt()
 
-        # def on_message(client, userdata, message):
-        #     print(f"message received {message.payload.decode('utf-8')}")
-
-        # self.mqtt_client.on_message = on_message
-
-        # self.mqtt_client.on_message = self.create_callback(mqtt_to_ros_topic_config["function"])
-
+        # Add message callbacks for MQTT topics
         for topic_config in mqtt_to_ros_topic_config:
             topic_name = topic_config['mqtt_topic_name']
             message_type = topic_config['message_type']
@@ -114,33 +114,35 @@ class MqttToRosBridge(Node):
         self.mqtt_client.loop_start()
 
     def create_callback(self, callback_function, topic_name):
+        """ Create a callback function for the subscription """
         def callback_wrapper(client, userdata, message):
-            # This wrapper function allows passing the topic name to the callback
-            msg = callback_function(message, topic_name)
+            """ 
+            This wrapper function allows sharing code between the callbacks
+            (we don't need to pass the topic names because the MQTT message already has this information)
+            """
+            mqtt_msg = callback_function(message)
             # Publish to ROS
-            msg1 = String()
-            msg1.data = msg
+            ros_msg = String()
+            ros_msg.data = mqtt_msg.payload.decode("utf-8")
             self.create_publisher(
-                String, topic_name, 10).publish(msg1)
+                String, topic_name, 10).publish(ros_msg)
 
         return callback_wrapper
 
-    def callback3(self, msg, topic_name):
-        # Callback function for topic1
-        # self.get_logger().info(
-        #     f'Received message on {topic_name} (callback3): {msg.data}')
+    def callback3(self, msg):
+        """ Callback function for topic1. Receives a Paho MQTT message object and returns a Paho MQTT message object """
+        self.get_logger().info(
+            f'Received MQTT message on {msg.topic} (callback3): {msg.payload.decode("utf-8")}')
         # Do some processing on msg here
-        # msg.data = msg.data + ' processed'
-        print(msg.payload.decode('utf-8'))
-        return msg.payload.decode('utf-8')
+        msg.payload = msg.payload + b' processed by callback3'
+        return msg
 
-    def callback4(self, msg, topic_name):
-        # Callback function for topic2
-        # self.get_logger().info(
-        #     f'Received message on {topic_name} (callback4): {msg.data}')
+    def callback4(self, msg):
+        """ Callback function for topic2 """
+        self.get_logger().info(
+            f'Received MQTT message on {msg.topic} (callback4): {msg.payload.decode("utf-8")}')
         # Do some processing on msg here
-        print(msg.payload.decode('utf-8'))
-        return msg.payload.decode('utf-8')
+        return msg
 
 
 def main(args=None):
@@ -155,6 +157,7 @@ def main(args=None):
     mqtt_to_ros_bridge = MqttToRosBridge(config)
     rclpy.spin(ros_to_mqtt_bridge)
     rclpy.spin(mqtt_to_ros_bridge)
+
     rclpy.shutdown()
 
 

--- a/src/ros/ros_to_mqtt/ros_to_mqtt/ros_to_mqtt.py
+++ b/src/ros/ros_to_mqtt/ros_to_mqtt/ros_to_mqtt.py
@@ -1,0 +1,36 @@
+import rclpy
+from rclpy.node import Node
+from rcl_interfaces.msg import Log
+
+
+class RosoutSubscriber(Node):
+    def __init__(self):
+        super().__init__('rosout_subscriber')
+
+        self.create_subscription(
+            Log,
+            'rosout',
+            self.rosout_callback,
+            10
+        )
+
+    def rosout_callback(self, msg):
+        # Process the received rosout message here
+        # We don't want to log the rosout_subscriber's own messages (or we'll get an infinite loop)
+        if (msg.name == "rosout_subscriber"):
+            return
+        self.log(msg)
+
+    def log(self, msg):
+        self.get_logger().info(f"ROSOUT: {msg.level}: {msg.name}: {msg.msg}")
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = RosoutSubscriber()
+    rclpy.spin(node)
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/ros/ros_to_mqtt/ros_to_mqtt/test_publisher.py
+++ b/src/ros/ros_to_mqtt/ros_to_mqtt/test_publisher.py
@@ -1,0 +1,60 @@
+# Copyright 2016 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+from rclpy.node import Node
+
+from std_msgs.msg import String
+
+
+class MinimalPublisher(Node):
+
+    def __init__(self):
+        super().__init__('minimal_publisher')
+        self.publisher1_ = self.create_publisher(String, 'topic1', 10)
+        self.publisher2_ = self.create_publisher(String, 'topic2', 10)
+        timer_period = 0.5  # seconds
+        self.timer = self.create_timer(timer_period, self.timer_callback)
+        self.i = 0
+
+    def timer_callback(self):
+        msg1 = String()
+        msg1.data = 'Hello World (1): %d' % self.i
+        self.publisher1_.publish(msg1)
+        self.get_logger().info('Publishing: "%s"' % msg1.data)
+
+        msg2 = String()
+        msg2.data = 'Hello World (2): %d' % self.i
+        self.publisher2_.publish(msg2)
+        self.get_logger().info('Publishing: "%s"' % msg2.data)
+
+        self.i += 1
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    minimal_publisher = MinimalPublisher()
+
+    rclpy.spin(minimal_publisher)
+
+    # Destroy the node explicitly
+    # (optional - otherwise it will be done automatically
+    # when the garbage collector destroys the node object)
+    minimal_publisher.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/ros/ros_to_mqtt/ros_to_mqtt/test_publisher.py
+++ b/src/ros/ros_to_mqtt/ros_to_mqtt/test_publisher.py
@@ -24,18 +24,18 @@ class MinimalPublisher(Node):
         super().__init__('minimal_publisher')
         self.publisher1_ = self.create_publisher(String, 'topic1', 10)
         self.publisher2_ = self.create_publisher(String, 'topic2', 10)
-        timer_period = 0.5  # seconds
+        timer_period = 1  # seconds
         self.timer = self.create_timer(timer_period, self.timer_callback)
         self.i = 0
 
     def timer_callback(self):
         msg1 = String()
-        msg1.data = 'Hello World (1): %d' % self.i
+        msg1.data = 'Topic 1: %d' % self.i
         self.publisher1_.publish(msg1)
         self.get_logger().info('Publishing: "%s"' % msg1.data)
 
         msg2 = String()
-        msg2.data = 'Hello World (2): %d' % self.i
+        msg2.data = 'Topic 2: %d' % self.i
         self.publisher2_.publish(msg2)
         self.get_logger().info('Publishing: "%s"' % msg2.data)
 

--- a/src/ros/ros_to_mqtt/setup.cfg
+++ b/src/ros/ros_to_mqtt/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/ros_to_mqtt
+[install]
+install_scripts=$base/lib/ros_to_mqtt

--- a/src/ros/ros_to_mqtt/setup.py
+++ b/src/ros/ros_to_mqtt/setup.py
@@ -21,7 +21,8 @@ setup(
     entry_points={
         'console_scripts': [
             'ros_to_mqtt = ros_to_mqtt.ros_to_mqtt:main',
-            'publisher = ros_to_mqtt.test_publisher:main',
+            'ros_publisher = ros_to_mqtt.ros_test_publisher:main',
+            'ros_listener = ros_to_mqtt.ros_listener:main'
         ],
     },
 )

--- a/src/ros/ros_to_mqtt/setup.py
+++ b/src/ros/ros_to_mqtt/setup.py
@@ -1,0 +1,27 @@
+from setuptools import setup
+
+package_name = 'ros_to_mqtt'
+
+setup(
+    name=package_name,
+    version='0.0.0',
+    packages=[package_name],
+    data_files=[
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+    ],
+    install_requires=['setuptools'],
+    zip_safe=True,
+    maintainer='David Beechey',
+    maintainer_email='s2206112@ed.ac.uk',
+    description='TODO: Package description',
+    license='TODO: License declaration',
+    tests_require=['pytest'],
+    entry_points={
+        'console_scripts': [
+            'ros_to_mqtt = ros_to_mqtt.ros_to_mqtt:main',
+            'publisher = ros_to_mqtt.test_publisher:main',
+        ],
+    },
+)

--- a/src/ros/ros_to_mqtt/setup.py
+++ b/src/ros/ros_to_mqtt/setup.py
@@ -15,7 +15,7 @@ setup(
     zip_safe=True,
     maintainer='David Beechey',
     maintainer_email='s2206112@ed.ac.uk',
-    description='TODO: Package description',
+    description='Converts ROS messages to MQTT for telemetry system.',
     license='TODO: License declaration',
     tests_require=['pytest'],
     entry_points={

--- a/src/ros/ros_to_mqtt/test/test_copyright.py
+++ b/src/ros/ros_to_mqtt/test/test_copyright.py
@@ -1,0 +1,25 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_copyright.main import main
+import pytest
+
+
+# Remove the `skip` decorator once the source file(s) have a copyright header
+@pytest.mark.skip(reason='No copyright header has been placed in the generated source file.')
+@pytest.mark.copyright
+@pytest.mark.linter
+def test_copyright():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found errors'

--- a/src/ros/ros_to_mqtt/test/test_flake8.py
+++ b/src/ros/ros_to_mqtt/test/test_flake8.py
@@ -1,0 +1,25 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_flake8.main import main_with_errors
+import pytest
+
+
+@pytest.mark.flake8
+@pytest.mark.linter
+def test_flake8():
+    rc, errors = main_with_errors(argv=[])
+    assert rc == 0, \
+        'Found %d code style errors / warnings:\n' % len(errors) + \
+        '\n'.join(errors)

--- a/src/ros/ros_to_mqtt/test/test_pep257.py
+++ b/src/ros/ros_to_mqtt/test/test_pep257.py
@@ -1,0 +1,23 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_pep257.main import main
+import pytest
+
+
+@pytest.mark.linter
+@pytest.mark.pep257
+def test_pep257():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found code style errors / warnings'


### PR DESCRIPTION
ROS package to convert ROS messages to MQTT messages (and vice versa) for telemetry (in Python). 

- `config.yaml` specifies which topics to subscribe and publish to in each direction, including callback functions for processing messages.
- `ros_to_mqtt` file contains the ROS to MQTT conversion code. The other files are for test publishers/subscribers for both ROS and MQTT for testing purposes.